### PR TITLE
`Response.successful`

### DIFF
--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -70,6 +70,8 @@ class Client:
         :type method: str
         :param endpoint: API endpoint to call (relative to the Base API path for this client).
         :type endpoint: str
+        :return: HTTP response
+        :rtype: :class:`requests.Response`
         """
         url = "/".join([self.origin, self.base_path, endpoint])
         response = requests.request(method, url, auth=self.auth, **kwargs)

--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -8,6 +8,12 @@ from requests import Response
 
 
 def successful(self):
+    """Checks that this response did not encounter an HTTP error (i.e. status code indicates success: 2xx, 3xx).
+
+    :raises :class:`requests.exceptions.HTTPError`: If an HTTP error is encountered.
+    :return: The calling response (i.e. ``self``).
+    :rtype: :class:`requests.Response`
+    """
     self.raise_for_status()
     return self
 

--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -3,6 +3,17 @@ import requests
 from tamr_unify_client.models.dataset.collection import DatasetCollection
 from tamr_unify_client.models.project.collection import ProjectCollection
 
+# monkey-patch Response.successful
+from requests import Response
+
+
+def successful(self):
+    self.raise_for_status()
+    return self
+
+
+Response.successful = successful
+
 
 class Client:
     """Python Client for Unify API. Each client is specific to a specific origin

--- a/tamr_unify_client/models/base_collection.py
+++ b/tamr_unify_client/models/base_collection.py
@@ -46,7 +46,7 @@ class BaseCollection(Iterable):
         :returns: The specified item.
         :rtype: ``resource_class``
         """
-        resource_json = self.client.get(relative_id).json()
+        resource_json = self.client.get(relative_id).successful().json()
         return resource_class.from_json(
             self.client, resource_json, api_path=relative_id
         )
@@ -63,7 +63,7 @@ class BaseCollection(Iterable):
         :returns: Generator that yields each item.
         :rtype: Python generator of ``resource_class``
         """
-        resources = self.client.get(self.api_path).json()
+        resources = self.client.get(self.api_path).successful().json()
         for resource_json in resources:
             yield resource_class.from_json(self.client, resource_json)
 

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -46,6 +46,6 @@ class Dataset(BaseResource):
         :param ``**options``: Options passed to underlying :class:`~tamr_unify_client.models.operation.Operation` .
             See :func:`~tamr_unify_client.models.operation.Operation.apply_options` .
         """
-        op_json = self.client.post(self.api_path + ":refresh").json()
+        op_json = self.client.post(self.api_path + ":refresh").successful().json()
         op = Operation.from_json(self.client, op_json)
         return op.apply_options(**options)

--- a/tamr_unify_client/models/machine_learning_model.py
+++ b/tamr_unify_client/models/machine_learning_model.py
@@ -15,7 +15,7 @@ class MachineLearningModel(BaseResource):
         :param ``**options``: Options passed to underlying :class:`~tamr_unify_client.models.operation.Operation` .
             See :func:`~tamr_unify_client.models.operation.Operation.apply_options` .
         """
-        op_json = self.client.post(self.api_path + ":refresh").json()
+        op_json = self.client.post(self.api_path + ":refresh").successful().json()
         op = Operation.from_json(self.client, op_json)
         return op.apply_options(**options)
 
@@ -26,6 +26,6 @@ class MachineLearningModel(BaseResource):
             See :func:`~tamr_unify_client.models.operation.Operation.apply_options` .
         """
         dependent_dataset = "/".join(self.api_path.split("/")[:-1])
-        op_json = self.client.post(dependent_dataset + ":refresh").json()
+        op_json = self.client.post(dependent_dataset + ":refresh").successful().json()
         op = Operation.from_json(self.client, op_json)
         return op.apply_options(**options)

--- a/tamr_unify_client/models/operation.py
+++ b/tamr_unify_client/models/operation.py
@@ -90,7 +90,7 @@ class Operation(BaseResource):
         :return: Updated representation of this operation.
         :rtype: :class:`~tamr_unify_client.models.Operation`
         """
-        op_json = self.client.get(self.api_path).json()
+        op_json = self.client.get(self.api_path).successful().json()
         return Operation.from_json(self.client, op_json)
 
     def wait(self, poll_interval_seconds=3, timeout_seconds=None):

--- a/tamr_unify_client/models/project/resource.py
+++ b/tamr_unify_client/models/project/resource.py
@@ -38,7 +38,7 @@ class Project(BaseResource):
         :rtype: :class:`~tamr_unify_client.models.dataset.resource.Dataset`
         """
         alias = self.api_path + "/unifiedDataset"
-        resource_json = self.client.get(alias).json()
+        resource_json = self.client.get(alias).successful().json()
         return Dataset.from_json(self.client, resource_json, alias)
 
     def as_categorization(self):

--- a/tests/mock_api/test_continuous_categorization.py
+++ b/tests/mock_api/test_continuous_categorization.py
@@ -2,7 +2,7 @@ from .utils import mock_api
 import os
 
 from tamr_unify_client.auth import UsernamePasswordAuth
-import tamr_unify_client as api
+from tamr_unify_client import Client
 
 
 basedir = os.path.dirname(__file__)
@@ -14,7 +14,7 @@ response_log_path = os.path.join(
 @mock_api(response_log_path)
 def test_continuous_categorization():
     auth = UsernamePasswordAuth("username", "password")
-    unify = api.Client(auth)
+    unify = Client(auth)
 
     project_id = "3"
     project = unify.projects.by_resource_id(project_id)

--- a/tests/mock_api/test_continuous_mastering.py
+++ b/tests/mock_api/test_continuous_mastering.py
@@ -2,7 +2,7 @@ from .utils import mock_api
 import os
 
 from tamr_unify_client.auth import UsernamePasswordAuth
-import tamr_unify_client as api
+from tamr_unify_client import Client
 
 
 basedir = os.path.dirname(__file__)
@@ -14,7 +14,7 @@ response_log_path = os.path.join(
 @mock_api(response_log_path)
 def test_continuous_mastering():
     auth = UsernamePasswordAuth("username", "password")
-    unify = api.Client(auth)
+    unify = Client(auth)
 
     project_id = "1"
     project = unify.projects.by_resource_id(project_id)

--- a/tests/unit/test_http_error.py
+++ b/tests/unit/test_http_error.py
@@ -1,0 +1,19 @@
+import responses
+from requests.exceptions import HTTPError
+import pytest
+
+from tamr_unify_client.auth import UsernamePasswordAuth
+from tamr_unify_client import Client
+
+
+@responses.activate
+def test_http_error():
+    """Ensure that the client surfaces HTTP errors as exceptions.
+    """
+    endpoint = f"http://localhost:9100/api/versioned/v1/projects/1"
+    responses.add(responses.GET, endpoint, status=401)
+    auth = UsernamePasswordAuth("nonexistent-username", "invalid-password")
+    unify = Client(auth)
+    with pytest.raises(HTTPError) as e:
+        project = unify.projects.by_resource_id("1")
+    assert f"401 Client Error: Unauthorized for url: {endpoint}" in str(e)


### PR DESCRIPTION
Fixes #5 

...monky-patched `requests.Response` method to:
1. raise HTTP errors as exceptions
2. return the response (for method chaining)

This PR also adds unit tests to ensure the client correctly surfaces HTTP errors as exceptions.