### PR TITLE
Readthedocs: py3.6 compatibility + linking from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ Programmatically 💻 interact with Tamr Unify using Python 🐍
 
 ---
 
-## Docs
-
-<!--- TODO link to readthedocs.com -->
+## [Docs](https://tamr-unify-python-client.readthedocs.io/en/stable/)
 
 ## Features
 <!--- TODO link each feature to docs -->

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,6 @@
+# http://blog.readthedocs.com/python-36-support/
+build:
+    image: latest
+
+python:
+    version: 3.6


### PR DESCRIPTION
This PR:

- fixes readthedocs compatibility for python 3.6 ([details](http://blog.readthedocs.com/python-36-support/))
- links to readthedocs from the `Docs` header in the README

Before:
<img width="1440" alt="screen shot 2019-01-17 at 10 26 44 am" src="https://user-images.githubusercontent.com/1477317/51328903-594ea200-1a42-11e9-96d3-7ed9bf44b382.png">

After:
<img width="1440" alt="screen shot 2019-01-17 at 10 26 54 am" src="https://user-images.githubusercontent.com/1477317/51328916-5eabec80-1a42-11e9-9736-236262f578ef.png">
