### PR TITLE
Read files with appropriate encodings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import find_packages, setup
 import os
 
 project_root = os.path.dirname(__file__)
-with open(os.path.join(project_root, "VERSION.txt")) as f:
+with open(os.path.join(project_root, "VERSION.txt"), encoding="utf-8") as f:
     version = f.readline().rstrip()
 
-with open(os.path.join(project_root, "README.md"), "r") as f:
+with open(os.path.join(project_root, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
@@ -18,6 +18,7 @@ setup(
     license="Apache 2.0",
     packages=find_packages(),
     install_requires=["requests>=2.20.0"],
+    python_requires=">=3.6",
     maintainer="Pedro Cattori",
     maintainer_email="pedro.cattori@tamr.com",
     keywords=["tamr", "unify"],


### PR DESCRIPTION
`pip3 install` failed for me due to this omission.

Also specify required python version >= 3.6 (related to #33 )