### PR TITLE
Fix #43: `request()` with an absolute path resolves incorrectly

### DIFF
--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -1,3 +1,4 @@
+from urllib.parse import urljoin
 import requests
 
 from tamr_unify_client.models.dataset.collection import DatasetCollection
@@ -51,7 +52,7 @@ class Client:
         host="localhost",
         protocol="http",
         port=9100,
-        base_path="api/versioned/v1",
+        base_path="api/versioned/v1/",
     ):
         self.auth = auth
         self.host = host
@@ -91,7 +92,7 @@ class Client:
         :return: HTTP response
         :rtype: :class:`requests.Response`
         """
-        url = "/".join([self.origin, self.base_path, endpoint])
+        url = urljoin(self.origin + "/" + self.base_path, endpoint)
         response = requests.request(method, url, auth=self.auth, **kwargs)
 
         # logging

--- a/tests/unit/test_request_absolute_endpoint.py
+++ b/tests/unit/test_request_absolute_endpoint.py
@@ -1,0 +1,18 @@
+import responses
+
+from tamr_unify_client import Client
+from tamr_unify_client.auth import UsernamePasswordAuth
+
+
+@responses.activate
+def test_request_absolute_endpoint():
+    endpoint = "/api/service/health"
+    full_url = f"http://localhost:9100{endpoint}"
+    responses.add(responses.GET, full_url, json={})
+
+    client = Client(UsernamePasswordAuth("username", "password"))
+
+    # If client does not properly handle absolute paths, client.get() will
+    # raise a ConnectionRefused exception.
+    response = client.get(endpoint)
+    assert response.url == full_url


### PR DESCRIPTION
Use `urllib.parse.urljoin()` to create URLs, so that absolute paths are handled correctly.