### PR TITLE
Add flake8-import-order plugin

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,13 @@
+# NOTE: flake8 settings for black compatibility:
+# https://ljvmiranda921.github.io/notebook/2018/06/21/precommits-using-black-and-flake8/
+
 [flake8]
 ignore = E203, E266, E501, W503, F403, F401
 max-line-length = 88
 max-complexity = 18
-select = B,C,E,F,W,T4,B9
+select = B,C,E,F,I,W,T4,B9
+exclude = build,.venv,*.egg-info
 
-# NOTE: settings are taken from below link to make flake8 work with black: 
-# https://ljvmiranda921.github.io/notebook/2018/06/21/precommits-using-black-and-flake8/
+# flake8-import-order plugin
+import-order-style = google
+application-import-names = tamr_unify_client

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         "dev": [
             "Sphinx==1.8.2",
             "black==18.9b0",
-            "flake8==3.5.0",
+            "flake8==3.7.7",
+            "flake8-import-order==0.18.1",
             "pytest==3.8.2",
             "responses==0.10.4",
             "wheel==0.32.3",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from setuptools import find_packages, setup
 import os
+
+from setuptools import find_packages, setup
 
 project_root = os.path.dirname(__file__)
 with open(os.path.join(project_root, "VERSION.txt"), encoding="utf-8") as f:

--- a/tamr_unify_client/auth/username_password.py
+++ b/tamr_unify_client/auth/username_password.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
+
 from base64 import b64encode
+
 from requests.auth import HTTPBasicAuth
 from requests.utils import to_native_string
 

--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -1,11 +1,12 @@
 from urllib.parse import urljoin
+
 import requests
+from requests import Response
 
 from tamr_unify_client.models.dataset.collection import DatasetCollection
 from tamr_unify_client.models.project.collection import ProjectCollection
 
 # monkey-patch Response.successful
-from requests import Response
 
 
 def successful(self):

--- a/tamr_unify_client/models/operation.py
+++ b/tamr_unify_client/models/operation.py
@@ -1,4 +1,4 @@
-from time import time as now, sleep
+from time import sleep, time as now
 
 from tamr_unify_client.models.base_resource import BaseResource
 

--- a/tamr_unify_client/models/project/categorization.py
+++ b/tamr_unify_client/models/project/categorization.py
@@ -1,5 +1,5 @@
-from tamr_unify_client.models.project.resource import Project
 from tamr_unify_client.models.machine_learning_model import MachineLearningModel
+from tamr_unify_client.models.project.resource import Project
 
 
 class CategorizationProject(Project):

--- a/tamr_unify_client/models/project/mastering.py
+++ b/tamr_unify_client/models/project/mastering.py
@@ -1,6 +1,6 @@
-from tamr_unify_client.models.project.resource import Project
-from tamr_unify_client.models.machine_learning_model import MachineLearningModel
 from tamr_unify_client.models.dataset.resource import Dataset
+from tamr_unify_client.models.machine_learning_model import MachineLearningModel
+from tamr_unify_client.models.project.resource import Project
 
 
 class MasteringProject(Project):

--- a/tests/mock_api/test_continuous_categorization.py
+++ b/tests/mock_api/test_continuous_categorization.py
@@ -1,9 +1,8 @@
-from .utils import mock_api
 import os
 
-from tamr_unify_client.auth import UsernamePasswordAuth
 from tamr_unify_client import Client
-
+from tamr_unify_client.auth import UsernamePasswordAuth
+from .utils import mock_api
 
 basedir = os.path.dirname(__file__)
 response_log_path = os.path.join(

--- a/tests/mock_api/test_continuous_mastering.py
+++ b/tests/mock_api/test_continuous_mastering.py
@@ -1,9 +1,8 @@
-from .utils import mock_api
 import os
 
-from tamr_unify_client.auth import UsernamePasswordAuth
 from tamr_unify_client import Client
-
+from tamr_unify_client.auth import UsernamePasswordAuth
+from .utils import mock_api
 
 basedir = os.path.dirname(__file__)
 response_log_path = os.path.join(

--- a/tests/mock_api/utils.py
+++ b/tests/mock_api/utils.py
@@ -1,6 +1,7 @@
 from functools import wraps
 import json
 import re
+
 import responses
 
 

--- a/tests/unit/test_http_error.py
+++ b/tests/unit/test_http_error.py
@@ -1,9 +1,9 @@
-import responses
+from pytest import raises
 from requests.exceptions import HTTPError
-import pytest
+import responses
 
-from tamr_unify_client.auth import UsernamePasswordAuth
 from tamr_unify_client import Client
+from tamr_unify_client.auth import UsernamePasswordAuth
 
 
 @responses.activate
@@ -14,6 +14,6 @@ def test_http_error():
     responses.add(responses.GET, endpoint, status=401)
     auth = UsernamePasswordAuth("nonexistent-username", "invalid-password")
     unify = Client(auth)
-    with pytest.raises(HTTPError) as e:
+    with raises(HTTPError) as e:
         unify.projects.by_resource_id("1")
     assert f"401 Client Error: Unauthorized for url: {endpoint}" in str(e)


### PR DESCRIPTION
Running `flake .` in the root directory for this project now enforces [Google-style import ordering](https://google.github.io/styleguide/pyguide.html?showone=Imports_formatting#313-imports-formatting) ([example](https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_google.py)).