### PR TITLE
Improve repr of client object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.0-dev
   **ADDED**
   - Record Clusters API endpoint to finish working mastering workflow.
+  - [#78](https://github.com/Datatamer/unify-client-python/issues/78) Improved repr for Client instances
 
   **FIXED**
   - Mastering workflow example was missing the generate clusters step, which has been rectified using proper endpoint

--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -140,3 +140,14 @@ class Client:
         :rtype: :class:`~tamr_unify_client.models.DatasetCollection`
         """
         return self._datasets
+
+    def __repr__(self):
+        # intentionally leaving out auth in order to avoid security concerns
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"host={self.host!r}, "
+            f"protocol={self.protocol!r}, "
+            f"port={self.port!r}, "
+            f"base_path={self.base_path!r})"
+        )

--- a/tests/unit/test_strings.py
+++ b/tests/unit/test_strings.py
@@ -1,0 +1,21 @@
+from tamr_unify_client import Client
+from tamr_unify_client.auth import UsernamePasswordAuth
+
+
+def test_client_repr():
+    auth = UsernamePasswordAuth("username", "password")
+
+    unify = Client(auth)
+    rstr = f"{unify!r}"
+
+    assert rstr.startswith("tamr_unify_client.client.Client(")
+    assert "http" in rstr
+    assert rstr.endswith(")")
+    assert "password" not in rstr
+
+    unify = Client(auth, protocol="http", port=1234, base_path="foo/bar")
+    rstr = f"{unify!r}"
+
+    assert "'http'" in rstr
+    assert "1234" in rstr
+    assert "foo/bar" in rstr


### PR DESCRIPTION
# ↪️ Pull Request

Through example, I am proposing of a pattern for `__repr__` throughout the codebase.

This repr has strictly more information than the default object repr provided by Python, but makes no claims of being comprehensive or `eval`-able.

Related to #78 

## 💻 Examples

```python3
>>> from tamr_unify_client import Client
>>> c = Client(None)
>>> c
tamr_unify_client.client.Client(host='localhost', protocol='http', port=9100, base_path='api/versioned/v1/')@0x7fbc4a6f0780
```

## 🚨 Test instructions

unit tests added.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
- [x] Update relevant docs + docstrings
- [x] Add ("Added", "FIXED", "REMOVED") entry/entries for the current development version in the changelog
