### PR TITLE
Rename data field to _data (private)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@
   **FIXED**
   - Mastering workflow example was missing the generate clusters step, which has been rectified using proper endpoint
   - [#30](https://github.com/Datatamer/unify-client-python/issues/30) Better docs for how to call directly call APIs
+  - [#61](https://github.com/Datatamer/unify-client-python/issues/61) `data` field renamed to `_data` (private).
+
+  **REMOVED**
+  - [#61](https://github.com/Datatamer/unify-client-python/issues/61) `data` field renamed to `_data` (private).
 
 ## 0.3.0
+*released on 2019-3-1*
+
   **ADDED**
   - Versioning example in FAQ
   - Offline installation docs

--- a/tamr_unify_client/models/base_resource.py
+++ b/tamr_unify_client/models/base_resource.py
@@ -13,7 +13,7 @@ class BaseResource(AbstractBaseClass):
 
     def __init__(self, client, data, alias=None):
         self.client = client
-        self.data = data
+        self._data = data
         self.api_path = alias or data["relativeId"]
 
     @classmethod
@@ -23,7 +23,7 @@ class BaseResource(AbstractBaseClass):
     @property
     def relative_id(self):
         """:type: str"""
-        return self.data["relativeId"]
+        return self._data["relativeId"]
 
     @property
     def resource_id(self):

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -15,27 +15,27 @@ class Dataset(BaseResource):
     @property
     def name(self):
         """:type: str"""
-        return self.data["name"]
+        return self._data["name"]
 
     @property
     def external_id(self):
         """:type: str"""
-        return self.data["externalId"]
+        return self._data["externalId"]
 
     @property
     def description(self):
         """:type: str"""
-        return self.data["description"]
+        return self._data["description"]
 
     @property
     def version(self):
         """:type: str"""
-        return self.data["version"]
+        return self._data["version"]
 
     @property
     def tags(self):
         """:type: list[str]"""
-        return self.data["tags"]
+        return self._data["tags"]
 
     def update_records(self, records):
         """Send a batch of record creations/updates/deletions to this dataset.

--- a/tamr_unify_client/models/dataset_status.py
+++ b/tamr_unify_client/models/dataset_status.py
@@ -14,7 +14,7 @@ class DatasetStatus(BaseResource):
 
         :type: str
         """
-        return self.data["datasetName"]
+        return self._data["datasetName"]
 
     @property
     def relative_dataset_id(self) -> str:
@@ -22,7 +22,7 @@ class DatasetStatus(BaseResource):
 
         :type: str
         """
-        return self.data["relativeDatasetId"]
+        return self._data["relativeDatasetId"]
 
     @property
     def is_streamable(self) -> bool:
@@ -30,4 +30,4 @@ class DatasetStatus(BaseResource):
 
         :type: bool
         """
-        return self.data["isStreamable"]
+        return self._data["isStreamable"]

--- a/tamr_unify_client/models/operation.py
+++ b/tamr_unify_client/models/operation.py
@@ -48,16 +48,16 @@ class Operation(BaseResource):
     @property
     def type(self):
         """:type: str"""
-        return self.data["type"]
+        return self._data["type"]
 
     @property
     def description(self):
         """:type: str"""
-        return self.data["description"]
+        return self._data["description"]
 
     @property
     def status(self):
-        return self.data["status"]
+        return self._data["status"]
 
     @property
     def state(self):

--- a/tamr_unify_client/models/project/resource.py
+++ b/tamr_unify_client/models/project/resource.py
@@ -12,17 +12,17 @@ class Project(BaseResource):
     @property
     def name(self):
         """:type: str"""
-        return self.data["name"]
+        return self._data["name"]
 
     @property
     def external_id(self):
         """:type: str"""
-        return self.data["externalId"]
+        return self._data["externalId"]
 
     @property
     def description(self):
         """:type: str"""
-        return self.data["description"]
+        return self._data["description"]
 
     @property
     def type(self):
@@ -34,7 +34,7 @@ class Project(BaseResource):
 
         :type: str
         """
-        return self.data["type"]
+        return self._data["type"]
 
     def unified_dataset(self):
         """Unified dataset for this project.
@@ -61,7 +61,7 @@ class Project(BaseResource):
             raise TypeError(
                 f"Cannot convert project to categorization project. Project type: {self.type}"
             )
-        return CategorizationProject(self.client, self.data, self.api_path)
+        return CategorizationProject(self.client, self._data, self.api_path)
 
     def as_mastering(self):
         """Convert this project to a :class:`~tamr_unify_client.models.project.mastering.MasteringProject`
@@ -76,4 +76,4 @@ class Project(BaseResource):
             raise TypeError(
                 f"Cannot convert project to mastering project. Project type: {self.type}"
             )
-        return MasteringProject(self.client, self.data, self.api_path)
+        return MasteringProject(self.client, self._data, self.api_path)

--- a/tests/unit/test_dataset_by_external_id.py
+++ b/tests/unit/test_dataset_by_external_id.py
@@ -49,4 +49,4 @@ def test_dataset_by_external_id_succeeds():
     auth = UsernamePasswordAuth("username", "password")
     unify = Client(auth)
     actual_dataset = unify.datasets.by_external_id(dataset_external_id)
-    assert actual_dataset.data == dataset_json[0]
+    assert actual_dataset._data == dataset_json[0]

--- a/tests/unit/test_dataset_status.py
+++ b/tests/unit/test_dataset_status.py
@@ -24,4 +24,4 @@ def test_dataset_status():
 
     dataset = unify.datasets.by_resource_id(dataset_id)
     status = dataset.status()
-    assert status.data == status_json
+    assert status._data == status_json

--- a/tests/unit/test_project_by_external_id.py
+++ b/tests/unit/test_project_by_external_id.py
@@ -47,4 +47,4 @@ def test_project_by_external_id_succeeds():
     auth = UsernamePasswordAuth("username", "password")
     unify = Client(auth)
     actual_project = unify.projects.by_external_id(project_external_id)
-    assert actual_project.data == project_json[0]
+    assert actual_project._data == project_json[0]


### PR DESCRIPTION
# ↪️ Pull Request

In response to RFC #61

`_data` contains information that is undocumented and likely to change without notice.

## 🚨 Test instructions

Existing unit tests updated. Searched, via grep, for all references to "data". The only remaining references are in the `__init__` param and corresponding docstr for BaseResource (as intended).

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
- [x] Update relevant docs + docstrings
- [ ] Add ("Added", "FIXED", "REMOVED") entry/entries for the current development version in the changelog
