### PR TITLE
Pass requests.session to client as optional argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   **ADDED**
   - Record Clusters API endpoint to finish working mastering workflow.
   - [#78](https://github.com/Datatamer/unify-client-python/issues/78) Improved repr for Client instances
+  - [#42](https://github.com/Datatamer/unify-client-python/issues/42) Optional `session` argument to `Client` to use a specific `requests.Session` instance
 
   **FIXED**
   - Mastering workflow example was missing the generate clusters step, which has been rectified using proper endpoint

--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -36,8 +36,10 @@ class Client:
     :type protocol: str
     :param port: Unify instance main port. Default: `9100`
     :type port: int
-    :param base_path: Base API path. Requests made by this client will be relative to this path. Default: ``"api/versioned/v1/"``
+    :param base_path: Base API path. Requests made by this client will be relative to this path. Default: `'api/versioned/v1/'`
     :type base_path: str
+    :param session: Session to use for API calls. Default: A new default `requests.Session()`.
+    :type session: requests.Session
 
     Usage:
         >>> import tamr_unify_client as api
@@ -54,12 +56,14 @@ class Client:
         protocol="http",
         port=9100,
         base_path="api/versioned/v1/",
+        session=None,
     ):
         self.auth = auth
         self.host = host
         self.protocol = protocol
         self.port = port
         self.base_path = base_path
+        self.session = session or requests.Session()
 
         self._projects = ProjectCollection(self)
         self._datasets = DatasetCollection(self)
@@ -94,7 +98,7 @@ class Client:
         :rtype: :class:`requests.Response`
         """
         url = urljoin(self.origin + "/" + self.base_path, endpoint)
-        response = requests.request(method, url, auth=self.auth, **kwargs)
+        response = self.session.request(method, url, auth=self.auth, **kwargs)
 
         # logging
         if self.logger:

--- a/tests/unit/test_requests_session.py
+++ b/tests/unit/test_requests_session.py
@@ -1,0 +1,30 @@
+import requests
+import responses
+
+from tamr_unify_client import Client
+from tamr_unify_client.auth import UsernamePasswordAuth
+
+
+@responses.activate
+def test_request_session_cookie():
+    endpoint = "http://localhost:9100/api/versioned/v1/test"
+    responses.add(responses.GET, endpoint, json={})
+
+    session = requests.Session()
+    cookie = requests.cookies.create_cookie(
+        name="test_cookie", value="the-cookie-works"
+    )
+    session.cookies.set_cookie(cookie)
+
+    client = Client(UsernamePasswordAuth("username", "password"), session=session)
+
+    assert client.session is session
+
+    endpoint = "test"
+    client.get(endpoint)
+
+    assert len(responses.calls) == 1
+    req = responses.calls[0].request
+    assert req.url.endswith("test")
+    assert req.headers.get("Cookie") is not None
+    assert "test_cookie=" in req.headers.get("Cookie")


### PR DESCRIPTION
# ↪️ Pull Request

Resolves Issue #42 

## 💻 Examples

Here's an example using this functionality to avoid certificate validation for a test environment.
```python3
import requests
from tamr_unify_client import Client

session = requests.Session()
session.verify = False

# auth defined elsewhere
unify = Client(auth, protocol='https', session=session)
```

Here's an example setting a custom header, which could be necessary in certain secure network environments.
```
session = requests.Session()
session.headers.update({'x-test': 'true'})
unify = Client(auth, protocol='https', session=session)
```

Tested with local scripts which previously failed without monkey patching `requests` but now pass by using a custom session.

## ✔️ PR Todo

- [X] Added/updated testing for this change
- [X] Included links to related issues/PRs
- [X] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
    - Relevant portions of docs are derived from doc strings. Doc strings are updated.
- [X] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **ADDED**, **FIXED**, **REMOVED**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
