### PR TITLE
Trivial docstr fix (change "status" to "state")

### DIFF
--- a/tamr_unify_client/models/operation.py
+++ b/tamr_unify_client/models/operation.py
@@ -70,13 +70,13 @@ class Operation(BaseResource):
         Note: you only need to manually pick up server-side changes when opting into asynchronous mode when kicking off this operation.
 
         Usage:
-            >>> op.status # operation is currently 'PENDING'
+            >>> op.state # operation is currently 'PENDING'
             'PENDING'
             >>> op.wait() # continually polls until operation resolves
-            >>> op.status # incorrect usage; operation object status never changes.
+            >>> op.state # incorrect usage; operation object state never changes.
             'PENDING'
             >>> op = op.poll() # correct usage; use value returned by Operation.poll or Operation.wait
-            >>> op.status
+            >>> op.state
             'SUCCEEDED'
         """
         return self.status["state"]


### PR DESCRIPTION
# ↪️ Pull Request

Trivial docstr fix to change "status" to "state", which was the intended method.

## ✔️ PR Todo

Ignoring most of the PR ToDo based on this being a trivial change. Not worth mentioning in changelog, testing, or filing an issue.

- [ ] Added/updated testing for this change
- [ ] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **ADDED**, **FIXED**, **REMOVED**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
