### PR TITLE
Useful reprs for all objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.0-dev
   **BREAKING CHANGES**
   - [#61](https://github.com/Datatamer/unify-client-python/issues/61) `data` field renamed to `_data` (private).
+  - [#78](https://github.com/Datatamer/unify-client-python/issues/78) Property accessors return `None` rather than raise `KeyError`
 
   **NEW FEATURES**
   - Record Clusters API endpoint to finish working mastering workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
   **NEW FEATURES**
   - Record Clusters API endpoint to finish working mastering workflow.
-  - [#78](https://github.com/Datatamer/unify-client-python/issues/78) Improved repr for Client instances
+  - [#78](https://github.com/Datatamer/unify-client-python/issues/78) Improved repr for objects through the library
   - [#42](https://github.com/Datatamer/unify-client-python/issues/42) Optional `session` argument to `Client` to use a specific `requests.Session` instance
 
   **BUG FIXES**

--- a/tamr_unify_client/auth/token.py
+++ b/tamr_unify_client/auth/token.py
@@ -8,3 +8,7 @@ class TokenAuth(AuthBase):
     def __call__(self, r):
         r.headers["Authorization"] = "BasicCreds " + self.token
         return r
+
+    def __repr__(self):
+        # intentionally leave out the token (potentially sensitive)
+        return f"{self.__class__.__module__}." f"{self.__class__.__qualname__}()"

--- a/tamr_unify_client/auth/username_password.py
+++ b/tamr_unify_client/auth/username_password.py
@@ -32,3 +32,11 @@ class UsernamePasswordAuth(HTTPBasicAuth):
     def __call__(self, r):
         r.headers["Authorization"] = _basic_auth_str(self.username, self.password)
         return r
+
+    def __repr__(self):
+        # intentionally leave out password (potentially sensitive)
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"username={self.username!r})"
+        )

--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -146,12 +146,13 @@ class Client:
         return self._datasets
 
     def __repr__(self):
-        # intentionally leaving out auth in order to avoid security concerns
+        # Show only the type `auth` to mitigate any security concerns.
         return (
             f"{self.__class__.__module__}."
             f"{self.__class__.__qualname__}("
             f"host={self.host!r}, "
             f"protocol={self.protocol!r}, "
             f"port={self.port!r}, "
-            f"base_path={self.base_path!r})"
+            f"base_path={self.base_path!r}, "
+            f"auth={type(self.auth).__name__})"
         )

--- a/tamr_unify_client/models/base_collection.py
+++ b/tamr_unify_client/models/base_collection.py
@@ -101,3 +101,10 @@ class BaseCollection(Iterable):
             )
 
         return items[0]
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"api_path={self.api_path!r})"
+        )

--- a/tamr_unify_client/models/base_resource.py
+++ b/tamr_unify_client/models/base_resource.py
@@ -13,8 +13,8 @@ class BaseResource(AbstractBaseClass):
 
     def __init__(self, client, data, alias=None):
         self.client = client
-        self._data = data
-        self.api_path = alias or data["relativeId"]
+        self._data = data or {}
+        self.api_path = alias or data.get("relativeId")
 
     @classmethod
     def from_data(cls, client, data, api_path=None):
@@ -23,9 +23,12 @@ class BaseResource(AbstractBaseClass):
     @property
     def relative_id(self):
         """:type: str"""
-        return self._data["relativeId"]
+        return self._data.get("relativeId")
 
     @property
     def resource_id(self):
         """:type: str"""
-        return self.relative_id.split("/")[-1]
+        rid = self.relative_id
+        if rid is None:
+            return None
+        return rid.split("/")[-1]

--- a/tamr_unify_client/models/dataset/collection.py
+++ b/tamr_unify_client/models/dataset/collection.py
@@ -76,3 +76,5 @@ class DatasetCollection(BaseCollection):
             if dataset.name == dataset_name:
                 return dataset
         raise KeyError(f"No dataset found with name: {dataset_name}")
+
+    # super.__repr__ is sufficient

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -76,3 +76,12 @@ class Dataset(BaseResource):
         return DatasetStatus.from_json(
             self.client, status_json, api_path=self.api_path + "/status"
         )
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"relative_id={self.relative_id!r}, "
+            f"name={self.name!r}, "
+            f"version={self.version!r})"
+        )

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -15,27 +15,27 @@ class Dataset(BaseResource):
     @property
     def name(self):
         """:type: str"""
-        return self._data["name"]
+        return self._data.get("name")
 
     @property
     def external_id(self):
         """:type: str"""
-        return self._data["externalId"]
+        return self._data.get("externalId")
 
     @property
     def description(self):
         """:type: str"""
-        return self._data["description"]
+        return self._data.get("description")
 
     @property
     def version(self):
         """:type: str"""
-        return self._data["version"]
+        return self._data.get("version")
 
     @property
     def tags(self):
         """:type: list[str]"""
-        return self._data["tags"]
+        return self._data.get("tags")
 
     def update_records(self, records):
         """Send a batch of record creations/updates/deletions to this dataset.

--- a/tamr_unify_client/models/dataset_status.py
+++ b/tamr_unify_client/models/dataset_status.py
@@ -31,3 +31,13 @@ class DatasetStatus(BaseResource):
         :type: bool
         """
         return self._data["isStreamable"]
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"relative_id={self.relative_id!r}, "
+            f"dataset_name={self.dataset_name!r}, "
+            f"relative_dataset_id={self.relative_dataset_id!r}, "
+            f"is_streamable={self.is_streamable!r})"
+        )

--- a/tamr_unify_client/models/dataset_status.py
+++ b/tamr_unify_client/models/dataset_status.py
@@ -14,7 +14,7 @@ class DatasetStatus(BaseResource):
 
         :type: str
         """
-        return self._data["datasetName"]
+        return self._data.get("datasetName")
 
     @property
     def relative_dataset_id(self) -> str:
@@ -22,7 +22,7 @@ class DatasetStatus(BaseResource):
 
         :type: str
         """
-        return self._data["relativeDatasetId"]
+        return self._data.get("relativeDatasetId")
 
     @property
     def is_streamable(self) -> bool:
@@ -30,7 +30,7 @@ class DatasetStatus(BaseResource):
 
         :type: bool
         """
-        return self._data["isStreamable"]
+        return self._data.get("isStreamable")
 
     def __repr__(self) -> str:
         return (

--- a/tamr_unify_client/models/machine_learning_model.py
+++ b/tamr_unify_client/models/machine_learning_model.py
@@ -29,3 +29,10 @@ class MachineLearningModel(BaseResource):
         op_json = self.client.post(dependent_dataset + ":refresh").successful().json()
         op = Operation.from_json(self.client, op_json)
         return op.apply_options(**options)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"relative_id={self.relative_id!r})"
+        )

--- a/tamr_unify_client/models/operation.py
+++ b/tamr_unify_client/models/operation.py
@@ -48,16 +48,16 @@ class Operation(BaseResource):
     @property
     def type(self):
         """:type: str"""
-        return self._data["type"]
+        return self._data.get("type")
 
     @property
     def description(self):
         """:type: str"""
-        return self._data["description"]
+        return self._data.get("description")
 
     @property
     def status(self):
-        return self._data["status"]
+        return self._data.get("status")
 
     @property
     def state(self):
@@ -79,7 +79,7 @@ class Operation(BaseResource):
             >>> op.state
             'SUCCEEDED'
         """
-        return self.status["state"]
+        return (self.status or {}).get("state")
 
     def poll(self):
         """Poll this operation for server-side updates.

--- a/tamr_unify_client/models/operation.py
+++ b/tamr_unify_client/models/operation.py
@@ -121,3 +121,12 @@ class Operation(BaseResource):
         :rtype: :py:class:`bool`
         """
         return self.state == "SUCCEEDED"
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"relative_id={self.relative_id!r}, "
+            f"description={self.description!r}, "
+            f"state={self.state!r})"
+        )

--- a/tamr_unify_client/models/project/categorization.py
+++ b/tamr_unify_client/models/project/categorization.py
@@ -14,3 +14,5 @@ class CategorizationProject(Project):
         """
         alias = self.api_path + "/categorizations/model"
         return MachineLearningModel(self.client, None, alias)
+
+    # super.__repr__ is sufficient

--- a/tamr_unify_client/models/project/collection.py
+++ b/tamr_unify_client/models/project/collection.py
@@ -61,3 +61,5 @@ class ProjectCollection(BaseCollection):
             >>>     do_stuff(project)
         """
         return super().stream(Project)
+
+    # super.__repr__ is sufficient

--- a/tamr_unify_client/models/project/mastering.py
+++ b/tamr_unify_client/models/project/mastering.py
@@ -75,3 +75,5 @@ class MasteringProject(Project):
         """
         alias = self.api_path + "/publishedClusters"
         return Dataset(self.client, None, alias)
+
+    # super.__repr__ is sufficient

--- a/tamr_unify_client/models/project/resource.py
+++ b/tamr_unify_client/models/project/resource.py
@@ -12,17 +12,17 @@ class Project(BaseResource):
     @property
     def name(self):
         """:type: str"""
-        return self._data["name"]
+        return self._data.get("name")
 
     @property
     def external_id(self):
         """:type: str"""
-        return self._data["externalId"]
+        return self._data.get("externalId")
 
     @property
     def description(self):
         """:type: str"""
-        return self._data["description"]
+        return self._data.get("description")
 
     @property
     def type(self):
@@ -34,7 +34,7 @@ class Project(BaseResource):
 
         :type: str
         """
-        return self._data["type"]
+        return self._data.get("type")
 
     def unified_dataset(self):
         """Unified dataset for this project.

--- a/tamr_unify_client/models/project/resource.py
+++ b/tamr_unify_client/models/project/resource.py
@@ -77,3 +77,12 @@ class Project(BaseResource):
                 f"Cannot convert project to mastering project. Project type: {self.type}"
             )
         return MasteringProject(self.client, self._data, self.api_path)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"relative_id={self.relative_id!r}, "
+            f"name={self.name!r}, "
+            f"type={self.type!r})"
+        )

--- a/tests/unit/test_strings.py
+++ b/tests/unit/test_strings.py
@@ -1,21 +1,77 @@
 from tamr_unify_client import Client
-from tamr_unify_client.auth import UsernamePasswordAuth
+from tamr_unify_client.auth import TokenAuth, UsernamePasswordAuth
+from tamr_unify_client.models.dataset_status import DatasetStatus
 
 
 def test_client_repr():
     auth = UsernamePasswordAuth("username", "password")
-
     unify = Client(auth)
+    full_clz_name = "tamr_unify_client.client.Client"
+
     rstr = f"{unify!r}"
 
-    assert rstr.startswith("tamr_unify_client.client.Client(")
+    assert rstr.startswith(f"{full_clz_name}(")
     assert "http" in rstr
-    assert rstr.endswith(")")
     assert "password" not in rstr
+    assert rstr.endswith(")")
 
+    # further testing when Client has optional arguments
     unify = Client(auth, protocol="http", port=1234, base_path="foo/bar")
     rstr = f"{unify!r}"
 
     assert "'http'" in rstr
     assert "1234" in rstr
     assert "foo/bar" in rstr
+
+
+def test_username_auth_repr():
+    auth = UsernamePasswordAuth("myusername", "SECRET")
+    full_clz_name = "tamr_unify_client.auth.username_password.UsernamePasswordAuth"
+
+    rstr = f"{auth!r}"
+
+    assert rstr.startswith(f"{full_clz_name}(")
+    assert "myusername" in rstr
+    assert "SECRET" not in rstr
+    assert rstr.endswith(")")
+
+
+def test_token_auth_repr():
+    auth = TokenAuth("SECRETTOKEN")
+    full_clz_name = "tamr_unify_client.auth.token.TokenAuth"
+
+    rstr = f"{auth!r}"
+
+    assert rstr == f"{full_clz_name}()"
+    assert "SECRETTOKEN" not in rstr
+
+
+def test_dataset_status_repr():
+    client = Client(UsernamePasswordAuth("username", "password"))
+    data = {
+        "relativeId": "path/to/thing/1",
+        "datasetName": "testdsname",
+        "relativeDatasetId": "path/to/data/1",
+        "isStreamable": True,
+    }
+    status = DatasetStatus.from_json(client, data)
+    full_clz_name = "tamr_unify_client.models.dataset_status.DatasetStatus"
+
+    rstr = f"{status!r}"
+
+    assert rstr.startswith(f"{full_clz_name}(")
+    assert "testdsname" in rstr
+    assert "True" in rstr
+    assert "path/to/thing" in rstr
+    assert rstr.endswith(")")
+
+
+def test_dataset_collection_repr():
+    client = Client(UsernamePasswordAuth("username", "password"))
+    full_clz_name = "tamr_unify_client.models.dataset.collection.DatasetCollection"
+
+    rstr = f"{client.datasets!r}"
+
+    assert rstr.startswith(f"{full_clz_name}(")
+    assert "api_path='datasets'" in rstr
+    assert rstr.endswith(")")


### PR DESCRIPTION
# ↪️ Pull Request

Issue #78 

The goal is to show useful values for developers during exploration,
debugging, or logging. These reprs do not show all possible
distinguishing values. The repr format is not documented and may change
without notice.

## 💻 Examples

```text
unify: tamr_unify_client.client.Client(host='localhost', protocol='https', port=4443, base_path='api/versioned/v1/', auth=UsernamePasswordAuth)
project: tamr_unify_client.models.project.mastering.MasteringProject(relative_id='projects/3', name='idogs', type='DEDUP')
```

## ✔️ PR Todo

- [X] Added/updated testing for this change
- [X] Included links to related issues/PRs
- [X] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [X] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **ADDED**, **FIXED**, **REMOVED**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
