### PR TITLE
Access to Attributes of a Dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.5.0-dev
+  **NEW FEATURES**
+  - [#94](https://github.com/Datatamer/unify-client-python/issues/94) Add access to Attributes of a Dataset
 
 ## 0.4.0
   **BREAKING CHANGES**

--- a/docs/developer-interface.rst
+++ b/docs/developer-interface.rst
@@ -31,6 +31,21 @@ Datasets
 .. autoclass:: tamr_unify_client.models.dataset.collection.DatasetCollection
   :members:
 
+Attribute
+---------
+
+.. autoclass:: tamr_unify_client.models.attribute.resource.Attribute
+
+Attribute Type
+--------------
+
+.. autoclass:: tamr_unify_client.models.attribute.type.AttributeType
+
+Attributes
+----------
+
+.. autoclass:: tamr_unify_client.models.attribute.collection.AttributeCollection
+
 Machine Learning Models
 -----------------------
 

--- a/tamr_unify_client/models/attribute/collection.py
+++ b/tamr_unify_client/models/attribute/collection.py
@@ -43,7 +43,9 @@ class AttributeCollection(BaseCollection):
         """
         split_id = relative_id.split("/")
         if split_id[:-1] != self.api_path:
-            raise ValueError(f"Attribute f{relative_id} is not in collection {self.api_path}")
+            raise ValueError(
+                f"Attribute f{relative_id} is not in collection {self.api_path}"
+            )
         resource_id = split_id[-1]
         return self.by_resource_id(resource_id)
 
@@ -63,17 +65,17 @@ class AttributeCollection(BaseCollection):
         raise NotImplementedError("Attributes do not have external_id")
 
     def stream(self):
-        """Stream datasets in this collection. Implicitly called when iterating
+        """Stream attributes in this collection. Implicitly called when iterating
         over this collection.
 
-        :returns: Stream of datasets.
-        :rtype: Python generator yielding :class:`~tamr_unify_client.models.dataset.resource.Dataset`
+        :returns: Stream of attributes.
+        :rtype: Python generator yielding :class:`~tamr_unify_client.models.attribute.resource.Attribute`
 
         Usage:
-            >>> for dataset in collection.stream(): # explicit
-            >>>     do_stuff(dataset)
-            >>> for dataset in collection: # implicit
-            >>>     do_stuff(dataset)
+            >>> for attribute in collection.stream(): # explicit
+            >>>     do_stuff(attribute)
+            >>> for attribute in collection: # implicit
+            >>>     do_stuff(attribute)
         """
         for resource_json in self._data:
             alias = self.api_path + "/" + resource_json["name"]

--- a/tamr_unify_client/models/attribute/collection.py
+++ b/tamr_unify_client/models/attribute/collection.py
@@ -41,12 +41,7 @@ class AttributeCollection(BaseCollection):
         :returns: The specified attribute.
         :rtype: :class:`~tamr_unify_client.models.attribute.resource.Attribute`
         """
-        split_id = relative_id.split("/")
-        if split_id[:-1] != self.api_path:
-            raise ValueError(
-                f"Attribute f{relative_id} is not in collection {self.api_path}"
-            )
-        resource_id = split_id[-1]
+        resource_id = relative_id.split("/")[-1]
         return self.by_resource_id(resource_id)
 
     def by_external_id(self, external_id):

--- a/tamr_unify_client/models/attribute/collection.py
+++ b/tamr_unify_client/models/attribute/collection.py
@@ -7,7 +7,8 @@ class AttributeCollection(BaseCollection):
 
     :param client: Client for API call delegation.
     :type client: :class:`~tamr_unify_client.Client`
-    :param :py:class:`dict` data: JSON data representing this resource
+    :param data: JSON data representing this resource
+    :type data: dict
     :param api_path: API path used to access this collection.
         E.g. ``"datasets/1/attributes"``.
     :type api_path: str
@@ -48,7 +49,7 @@ class AttributeCollection(BaseCollection):
         """Retrieve an attribute by external ID.
 
         Since attributes do not have external IDs, this method is not supported and will
-        raise a NotImplementedError.
+        raise a :class:`NotImplementedError` .
 
         :param external_id: The external ID.
         :type external_id: str

--- a/tamr_unify_client/models/attribute/collection.py
+++ b/tamr_unify_client/models/attribute/collection.py
@@ -1,0 +1,96 @@
+from tamr_unify_client.models.attribute.resource import Attribute
+from tamr_unify_client.models.base_collection import BaseCollection
+
+
+class AttributeCollection(BaseCollection):
+    """Collection of :class:`~tamr_unify_client.models.attribute.resource.Attribute` s.
+
+    :param client: Client for API call delegation.
+    :type client: :class:`~tamr_unify_client.Client`
+    :param :py:class:`dict` data: JSON data representing this resource
+    :param api_path: API path used to access this collection.
+        E.g. ``"datasets/1/attributes"``.
+    :type api_path: str
+    """
+
+    def __init__(self, client, data, api_path):
+        super().__init__(client, api_path)
+        self._data = data
+
+    @classmethod
+    def from_json(cls, client, data, api_path):
+        # BaseCollection doesn't really implement from_json / from_data
+        # but we pretend it does.
+        return AttributeCollection(client, data, api_path)
+
+    def by_resource_id(self, resource_id):
+        """Retrieve an attribute by resource ID.
+
+        :param resource_id: The resource ID. E.g. ``"AttributeName"``
+        :type resource_id: str
+        :returns: The specified attribute.
+        :rtype: :class:`~tamr_unify_client.models.attribute.resource.Attribute`
+        """
+        return self.by_name(resource_id)
+
+    def by_relative_id(self, relative_id):
+        """Retrieve an attribute by relative ID.
+
+        :param relative_id: The resource ID. E.g. ``"datasets/1/attributes/AttributeName"``
+        :type relative_id: str
+        :returns: The specified attribute.
+        :rtype: :class:`~tamr_unify_client.models.attribute.resource.Attribute`
+        """
+        split_id = relative_id.split("/")
+        if split_id[:-1] != self.api_path:
+            raise ValueError(f"Attribute f{relative_id} is not in collection {self.api_path}")
+        resource_id = split_id[-1]
+        return self.by_resource_id(resource_id)
+
+    def by_external_id(self, external_id):
+        """Retrieve an attribute by external ID.
+
+        Since attributes do not have external IDs, this method is not supported and will
+        raise a NotImplementedError.
+
+        :param external_id: The external ID.
+        :type external_id: str
+        :returns: The specified attribute, if found.
+        :rtype: :class:`~tamr_unify_client.models.attribute.resource.Attribute`
+        :raises KeyError: If no attribute with the specified external_id is found
+        :raises LookupError: If multiple attributes with the specified external_id are found
+        """
+        raise NotImplementedError("Attributes do not have external_id")
+
+    def stream(self):
+        """Stream datasets in this collection. Implicitly called when iterating
+        over this collection.
+
+        :returns: Stream of datasets.
+        :rtype: Python generator yielding :class:`~tamr_unify_client.models.dataset.resource.Dataset`
+
+        Usage:
+            >>> for dataset in collection.stream(): # explicit
+            >>>     do_stuff(dataset)
+            >>> for dataset in collection: # implicit
+            >>>     do_stuff(dataset)
+        """
+        for resource_json in self._data:
+            alias = self.api_path + "/" + resource_json["name"]
+            yield Attribute.from_json(self.client, resource_json, alias)
+
+    def by_name(self, attribute_name):
+        """Lookup a specific attribute in this collection by exact-match on name.
+
+        :param attribute_name: Name of the desired attribute.
+        :type attribute_name: str
+        :return: Attribute with matching name in this collection.
+        :rtype: :class:`~tamr_unify_client.models.attribute.resource.Attribute`
+        :raises KeyError: If no attribute with specified name was found.
+        """
+        for attribute in self:
+            if attribute.name == attribute_name:
+                return attribute
+        raise KeyError(f"No attribute found with name: {attribute_name}")
+
+    # super.__repr__ is sufficient

--- a/tamr_unify_client/models/attribute/resource.py
+++ b/tamr_unify_client/models/attribute/resource.py
@@ -15,6 +15,20 @@ class Attribute(BaseResource):
 
     @property
     def relative_id(self):
+        """:type: str"""
+        # api_path is alias when it exists, and relative_id when it does not.
+        # this distinction is useful for things like refreshing a unified dataset,
+        # where using the relative_id would hit
+        #   /datasets/{id}:refresh
+        # rather than
+        #   /projects/{id}/unifiedDataset:refresh.
+        # Since attributes don't currently have that kind of aliasing,
+        # using api_path is always correct.
+        # If attributes ever get aliased, this will need to be updated.
+        # This is confusing; there's an RFC for suggestions to improve this
+        # #64 https://github.com/Datatamer/unify-client-python/issues/64
+        # "Conflation between 'api_path', 'relative_id' / 'relativeId', and
+        # BaseResource ctor 'alias'"
         return self.api_path
 
     @property

--- a/tamr_unify_client/models/attribute/resource.py
+++ b/tamr_unify_client/models/attribute/resource.py
@@ -1,0 +1,48 @@
+from tamr_unify_client.models.attribute.type import AttributeType
+from tamr_unify_client.models.base_resource import BaseResource
+
+
+class Attribute(BaseResource):
+    """
+    A Unify Attribute.
+
+    See https://docs.tamr.com/reference#attribute-types
+    """
+
+    @classmethod
+    def from_json(cls, client, data, api_path):
+        return super().from_data(client, data, api_path)
+
+    @property
+    def relative_id(self):
+        return self.api_path
+
+    @property
+    def name(self):
+        """:type: str"""
+        return self._data.get("name")
+
+    @property
+    def description(self):
+        """:type: str"""
+        return self._data.get("description")
+
+    @property
+    def type(self):
+        """:type: :class:`~tamr_unify_client.models.attribute.type.AttributeType`"""
+        alias = self.api_path + "/type"
+        type_json = self._data.get("type")
+        return AttributeType.from_data(self.client, type_json, alias)
+
+    @property
+    def is_nullable(self):
+        """:type: bool"""
+        return self._data.get("isNullable")
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"relative_id={self.relative_id!r}, "
+            f"name={self.name!r})"
+        )

--- a/tamr_unify_client/models/attribute/type.py
+++ b/tamr_unify_client/models/attribute/type.py
@@ -2,12 +2,8 @@ from tamr_unify_client.models.base_resource import BaseResource
 
 
 class AttributeType(BaseResource):
-
     @classmethod
     def from_json(cls, client, data, api_path):
-        # Need to fill in this path
-        # This attribute might be part of the collection on a dataset, or
-        # this attribute might be part of the collection on an attribute
         return super().from_data(client, data, api_path)
 
     @property
@@ -24,7 +20,9 @@ class AttributeType(BaseResource):
         """:type: :class:`~tamr_unify_client.models.attribute.type.AttributeType`"""
         if "innerType" in self._data:
             alias = self.api_path + "/type"
-            return AttributeType.from_data(self.client, self._data.get("innerType"), alias)
+            return AttributeType.from_data(
+                self.client, self._data.get("innerType"), alias
+            )
         else:
             return None
 
@@ -34,6 +32,7 @@ class AttributeType(BaseResource):
         collection_json = self._data.get("attributes")
         # Import locally to avoid circular dependency
         from tamr_unify_client.models.attribute.collection import AttributeCollection
+
         return AttributeCollection.from_json(self.client, collection_json, alias)
 
     def __repr__(self):

--- a/tamr_unify_client/models/attribute/type.py
+++ b/tamr_unify_client/models/attribute/type.py
@@ -1,0 +1,45 @@
+from tamr_unify_client.models.base_resource import BaseResource
+
+
+class AttributeType(BaseResource):
+
+    @classmethod
+    def from_json(cls, client, data, api_path):
+        # Need to fill in this path
+        # This attribute might be part of the collection on a dataset, or
+        # this attribute might be part of the collection on an attribute
+        return super().from_data(client, data, api_path)
+
+    @property
+    def relative_id(self):
+        return self.api_path
+
+    @property
+    def base_type(self):
+        """:type: str"""
+        return self._data.get("baseType")
+
+    @property
+    def inner_type(self):
+        """:type: :class:`~tamr_unify_client.models.attribute.type.AttributeType`"""
+        if "innerType" in self._data:
+            alias = self.api_path + "/type"
+            return AttributeType.from_data(self.client, self._data.get("innerType"), alias)
+        else:
+            return None
+
+    @property
+    def attributes(self):
+        alias = self.api_path + "/attributes"
+        collection_json = self._data.get("attributes")
+        # Import locally to avoid circular dependency
+        from tamr_unify_client.models.attribute.collection import AttributeCollection
+        return AttributeCollection.from_json(self.client, collection_json, alias)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"relative_id={self.relative_id!r}, "
+            f"base_type={self.base_type!r})"
+        )

--- a/tamr_unify_client/models/attribute/type.py
+++ b/tamr_unify_client/models/attribute/type.py
@@ -28,6 +28,7 @@ class AttributeType(BaseResource):
 
     @property
     def attributes(self):
+        """:type: :class:`~tamr_unify_client.models.attribute.collection.AttributeCollection`"""
         alias = self.api_path + "/attributes"
         collection_json = self._data.get("attributes")
         # Import locally to avoid circular dependency

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -54,7 +54,6 @@ class Dataset(BaseResource):
         resource_json = self.client.get(alias).successful().json()
         return AttributeCollection.from_json(self.client, resource_json, alias)
 
-
     def update_records(self, records):
         """Send a batch of record creations/updates/deletions to this dataset.
 

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -1,5 +1,6 @@
 import json
 
+from tamr_unify_client.models.attribute.collection import AttributeCollection
 from tamr_unify_client.models.base_resource import BaseResource
 from tamr_unify_client.models.dataset_status import DatasetStatus
 from tamr_unify_client.models.operation import Operation
@@ -36,6 +37,18 @@ class Dataset(BaseResource):
     def tags(self):
         """:type: list[str]"""
         return self._data.get("tags")
+
+    @property
+    def attributes(self):
+        """Attributes of this dataset.
+
+        :return: Attributes of this dataset.
+        :rtype: :class:`~tamr_unify_client.models.attribute.collection.AttributeCollection`
+        """
+        alias = self.api_path + "/attributes"
+        resource_json = self.client.get(alias).successful().json()
+        return AttributeCollection.from_json(self.client, resource_json, alias)
+
 
     def update_records(self, records):
         """Send a batch of record creations/updates/deletions to this dataset.

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -39,6 +39,11 @@ class Dataset(BaseResource):
         return self._data.get("tags")
 
     @property
+    def key_attribute_names(self):
+        """:type: list[str]"""
+        return self._data.get("keyAttributeNames")
+
+    @property
     def attributes(self):
         """Attributes of this dataset.
 

--- a/tests/unit/test_attribute.py
+++ b/tests/unit/test_attribute.py
@@ -46,16 +46,16 @@ class TestAttribute(TestCase):
     def test_complex_type(self):
         alias = "datasets/1/attributes/geom"
         geom = Attribute(self.unify, self._attributes_json[1], alias)
-        self.assertEqual('RECORD', geom.type.base_type)
+        self.assertEqual("RECORD", geom.type.base_type)
         self.assertIsNone(geom.type.inner_type)
         self.assertEqual(3, len(list(geom.type.attributes)))
 
         point = list(geom.type.attributes)[0]
-        self.assertEqual('point', point.name)
+        self.assertEqual("point", point.name)
         self.assertEqual(alias + "/type/attributes/point", point.relative_id)
         self.assertTrue(point.is_nullable)
-        self.assertEqual('ARRAY', point.type.base_type)
-        self.assertEqual('DOUBLE', point.type.inner_type.base_type)
+        self.assertEqual("ARRAY", point.type.base_type)
+        self.assertEqual("DOUBLE", point.type.inner_type.base_type)
         self.assertSequenceEqual([], list(point.type.attributes))
 
     @responses.activate
@@ -67,8 +67,7 @@ class TestAttribute(TestCase):
         dataset = self.unify.datasets.by_resource_id("1")
         print(dataset._data)
         self.assertSequenceEqual(
-            self._dataset_json["keyAttributeNames"],
-            dataset.key_attribute_names
+            self._dataset_json["keyAttributeNames"], dataset.key_attribute_names
         )
         attributes = list(dataset.attributes)
         self.assertEqual(2, len(attributes))
@@ -101,11 +100,8 @@ class TestAttribute(TestCase):
         {
             "name": "RowNum",
             "description": "Synthetic row number",
-            "type": {
-                "baseType": "STRING",
-                "attributes": []
-            },
-            "isNullable": False
+            "type": {"baseType": "STRING", "attributes": []},
+            "isNullable": False,
         },
         {
             "name": "geom",
@@ -117,13 +113,10 @@ class TestAttribute(TestCase):
                         "name": "point",
                         "type": {
                             "baseType": "ARRAY",
-                            "innerType": {
-                                "baseType": "DOUBLE",
-                                "attributes": []
-                            },
-                            "attributes": []
+                            "innerType": {"baseType": "DOUBLE", "attributes": []},
+                            "attributes": [],
                         },
-                        "isNullable": True
+                        "isNullable": True,
                     },
                     {
                         "name": "lineString",
@@ -131,15 +124,12 @@ class TestAttribute(TestCase):
                             "baseType": "ARRAY",
                             "innerType": {
                                 "baseType": "ARRAY",
-                                "innerType": {
-                                    "baseType": "DOUBLE",
-                                    "attributes": []
-                                },
-                                "attributes": []
+                                "innerType": {"baseType": "DOUBLE", "attributes": []},
+                                "attributes": [],
                             },
-                            "attributes": []
+                            "attributes": [],
                         },
-                        "isNullable": True
+                        "isNullable": True,
                     },
                     {
                         "name": "polygon",
@@ -151,18 +141,18 @@ class TestAttribute(TestCase):
                                     "baseType": "ARRAY",
                                     "innerType": {
                                         "baseType": "DOUBLE",
-                                        "attributes": []
+                                        "attributes": [],
                                     },
-                                    "attributes": []
+                                    "attributes": [],
                                 },
-                                "attributes": []
+                                "attributes": [],
                             },
-                            "attributes": []
+                            "attributes": [],
                         },
-                        "isNullable": True
-                    }
-                ]
+                        "isNullable": True,
+                    },
+                ],
             },
-            "isNullable": False
-        }
+            "isNullable": False,
+        },
     ]

--- a/tests/unit/test_attribute.py
+++ b/tests/unit/test_attribute.py
@@ -65,7 +65,6 @@ class TestAttribute(TestCase):
         responses.add(responses.GET, dataset_url, json=self._dataset_json)
         responses.add(responses.GET, attributes_url, json=self._attributes_json)
         dataset = self.unify.datasets.by_resource_id("1")
-        print(dataset._data)
         self.assertSequenceEqual(
             self._dataset_json["keyAttributeNames"], dataset.key_attribute_names
         )

--- a/tests/unit/test_attribute.py
+++ b/tests/unit/test_attribute.py
@@ -65,34 +65,37 @@ class TestAttribute(TestCase):
         responses.add(responses.GET, dataset_url, json=self._dataset_json)
         responses.add(responses.GET, attributes_url, json=self._attributes_json)
         dataset = self.unify.datasets.by_resource_id("1")
+        print(dataset._data)
+        self.assertSequenceEqual(
+            self._dataset_json["keyAttributeNames"],
+            dataset.key_attribute_names
+        )
         attributes = list(dataset.attributes)
         self.assertEqual(2, len(attributes))
         alias = "datasets/1/attributes/RowNum"
         self.assertEqual(alias, attributes[0].relative_id)
 
-    _dataset_json = [
-        {
-            "id": "unify://unified-data/v1/datasets/1",
-            "externalId": "number 1",
-            "name": "dataset 1 name",
-            "description": "dataset 1 description",
-            "version": "dataset 1 version",
-            "keyAttributeNames": ["tamr_id"],
-            "tags": [],
-            "created": {
-                "username": "admin",
-                "time": "2018-09-10T16:06:20.636Z",
-                "version": "dataset 1 created version",
-            },
-            "lastModified": {
-                "username": "admin",
-                "time": "2018-09-10T16:06:20.851Z",
-                "version": "dataset 1 modified version",
-            },
-            "relativeId": "datasets/1",
-            "upstreamDatasetIds": [],
-        }
-    ]
+    _dataset_json = {
+        "id": "unify://unified-data/v1/datasets/1",
+        "externalId": "number 1",
+        "name": "dataset 1 name",
+        "description": "dataset 1 description",
+        "version": "dataset 1 version",
+        "keyAttributeNames": ["tamr_id"],
+        "tags": [],
+        "created": {
+            "username": "admin",
+            "time": "2018-09-10T16:06:20.636Z",
+            "version": "dataset 1 created version",
+        },
+        "lastModified": {
+            "username": "admin",
+            "time": "2018-09-10T16:06:20.851Z",
+            "version": "dataset 1 modified version",
+        },
+        "relativeId": "datasets/1",
+        "upstreamDatasetIds": [],
+    }
 
     _attributes_json = [
         {

--- a/tests/unit/test_attribute.py
+++ b/tests/unit/test_attribute.py
@@ -1,0 +1,165 @@
+from unittest import TestCase
+
+import responses
+
+from tamr_unify_client import Client
+from tamr_unify_client.auth import UsernamePasswordAuth
+from tamr_unify_client.models.attribute.resource import Attribute
+
+
+class TestAttribute(TestCase):
+    def setUp(self):
+        auth = UsernamePasswordAuth("username", "password")
+        self.unify = Client(auth)
+
+    def test_resource(self):
+        alias = "datasets/1/attributes/RowNum"
+        row_num = Attribute(self.unify, self._attributes_json[0], alias)
+
+        expected = alias
+        self.assertEqual(expected, row_num.relative_id)
+
+        expected = self._attributes_json[0]["name"]
+        self.assertEqual(expected, row_num.name)
+
+        expected = self._attributes_json[0]["description"]
+        self.assertEqual(expected, row_num.description)
+
+        expected = self._attributes_json[0]["isNullable"]
+        self.assertEqual(expected, row_num.is_nullable)
+
+    def test_resource_from_json(self):
+        alias = "datasets/1/attributes/RowNum"
+        expected = Attribute(self.unify, self._attributes_json[0], alias)
+        actual = Attribute.from_json(self.unify, self._attributes_json[0], alias)
+        self.assertEqual(repr(expected), repr(actual))
+
+    def test_simple_type(self):
+        alias = "datasets/1/attributes/RowNum"
+        row_num = Attribute(self.unify, self._attributes_json[0], alias)
+        row_num_type = row_num.type
+        expected = self._attributes_json[0]["type"]["baseType"]
+        self.assertEqual(expected, row_num_type.base_type)
+        self.assertIsNone(row_num_type.inner_type)
+        self.assertSequenceEqual([], list(row_num_type.attributes))
+
+    def test_complex_type(self):
+        alias = "datasets/1/attributes/geom"
+        geom = Attribute(self.unify, self._attributes_json[1], alias)
+        self.assertEqual('RECORD', geom.type.base_type)
+        self.assertIsNone(geom.type.inner_type)
+        self.assertEqual(3, len(list(geom.type.attributes)))
+
+        point = list(geom.type.attributes)[0]
+        self.assertEqual('point', point.name)
+        self.assertEqual(alias + "/type/attributes/point", point.relative_id)
+        self.assertTrue(point.is_nullable)
+        self.assertEqual('ARRAY', point.type.base_type)
+        self.assertEqual('DOUBLE', point.type.inner_type.base_type)
+        self.assertSequenceEqual([], list(point.type.attributes))
+
+    @responses.activate
+    def test_dataset_attributes(self):
+        dataset_url = f"http://localhost:9100/api/versioned/v1/datasets/1"
+        attributes_url = f"http://localhost:9100/api/versioned/v1/datasets/1/attributes"
+        responses.add(responses.GET, dataset_url, json=self._dataset_json)
+        responses.add(responses.GET, attributes_url, json=self._attributes_json)
+        dataset = self.unify.datasets.by_resource_id("1")
+        attributes = list(dataset.attributes)
+        self.assertEqual(2, len(attributes))
+        alias = "datasets/1/attributes/RowNum"
+        self.assertEqual(alias, attributes[0].relative_id)
+
+    _dataset_json = [
+        {
+            "id": "unify://unified-data/v1/datasets/1",
+            "externalId": "number 1",
+            "name": "dataset 1 name",
+            "description": "dataset 1 description",
+            "version": "dataset 1 version",
+            "keyAttributeNames": ["tamr_id"],
+            "tags": [],
+            "created": {
+                "username": "admin",
+                "time": "2018-09-10T16:06:20.636Z",
+                "version": "dataset 1 created version",
+            },
+            "lastModified": {
+                "username": "admin",
+                "time": "2018-09-10T16:06:20.851Z",
+                "version": "dataset 1 modified version",
+            },
+            "relativeId": "datasets/1",
+            "upstreamDatasetIds": [],
+        }
+    ]
+
+    _attributes_json = [
+        {
+            "name": "RowNum",
+            "description": "Synthetic row number",
+            "type": {
+                "baseType": "STRING",
+                "attributes": []
+            },
+            "isNullable": False
+        },
+        {
+            "name": "geom",
+            "description": "",
+            "type": {
+                "baseType": "RECORD",
+                "attributes": [
+                    {
+                        "name": "point",
+                        "type": {
+                            "baseType": "ARRAY",
+                            "innerType": {
+                                "baseType": "DOUBLE",
+                                "attributes": []
+                            },
+                            "attributes": []
+                        },
+                        "isNullable": True
+                    },
+                    {
+                        "name": "lineString",
+                        "type": {
+                            "baseType": "ARRAY",
+                            "innerType": {
+                                "baseType": "ARRAY",
+                                "innerType": {
+                                    "baseType": "DOUBLE",
+                                    "attributes": []
+                                },
+                                "attributes": []
+                            },
+                            "attributes": []
+                        },
+                        "isNullable": True
+                    },
+                    {
+                        "name": "polygon",
+                        "type": {
+                            "baseType": "ARRAY",
+                            "innerType": {
+                                "baseType": "ARRAY",
+                                "innerType": {
+                                    "baseType": "ARRAY",
+                                    "innerType": {
+                                        "baseType": "DOUBLE",
+                                        "attributes": []
+                                    },
+                                    "attributes": []
+                                },
+                                "attributes": []
+                            },
+                            "attributes": []
+                        },
+                        "isNullable": True
+                    }
+                ]
+            },
+            "isNullable": False
+        }
+    ]


### PR DESCRIPTION
# ↪️ Pull Request

Access to Attributes of a Dataset.
Fix #94 

## 💻 Examples

```
>>> dataset1 = unify.datasets.by_resource_id("1")
>>> for attribute in dataset1.attributes:
...   print(attribute.relative_id)
...   print(attribute.name)
...   print(attribute.type.base_type)
... 
datasets/1/attributes/RowNum
RowNum
STRING
datasets/1/attributes/geo
geo
RECORD
```

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
