### PR TITLE
Implement Python Geo Interface on Dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.0-dev
   **NEW FEATURES**
   - [#94](https://github.com/Datatamer/unify-client-python/issues/94) Add access to Attributes of a Dataset
+  - [#98](https://github.com/Datatamer/unify-client-python/issues/98) Add `__geo_interface__` to Dataset
 
 ## 0.4.0
   **BREAKING CHANGES**

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ User Guide
   user-guide/quickstart
   user-guide/secure-credentials
   user-guide/workflows
+  user-guide/geo
   user-guide/advanced-usage
 
 Contributor Guide

--- a/docs/user-guide/geo.rst
+++ b/docs/user-guide/geo.rst
@@ -1,0 +1,61 @@
+Geospatial Data
+===============
+
+What geospatial data is supported?
+----------------------------------
+
+In general, the Python Geo Interface is supported; see https://gist.github.com/sgillies/2217756
+
+There are three layers of information:
+
+- The outermost layer is a FeatureCollection
+- Within a FeatureCollection are Features. Each feature has a type, an id, an optional
+  geometry, an optional bbox (bounding box), and optional properties.
+- A geometry has a type and coordinates.
+
+Although the Python Geo Interface is non-prescriptive when it comes to the data types of
+properties, Unify has a more restricted set of supported types. See https://docs.tamr.com/reference#attribute-types
+
+Unify allows any number of geometry attributes per record; the Python Geo Interface is limited to
+one. When converting Unify records to Python Geo Features, the first geometry attribute will
+be used as the geometry; all other geometry attributes will appear as properties.
+
+The :class:`~tamr_unify_client.models.dataset.resource.Dataset` class supports the
+``__geo_interface__`` property. This will produce one ``FeatureCollection`` for the entire dataset.
+
+There is a companion property ``__geo_features__`` that returns a generator that allows you to
+stream the records in the dataset as Geospatial features.
+
+To produce a GeoJSON representation of a dataset::
+
+  dataset = client.datasets.by_name("my_dataset")
+  with open("my_dataset.json", "w") as f:
+    json.dump(dataset.__geo_interface__, f)
+
+Rules for converting between Unify records and Geospatial Features
+------------------------------------------------------------------
+
+The record's primary key will be used as the feature's ``id``. If the primary key is a single
+attribute, then the value of that attribute will be the value of ``id``. If the primary key is
+composed of multiple attributes, then the value of the ``id`` will be an array with the values
+of the key attributes in order.
+
+The first attribute with type ``RECORD`` containing an attribute named ``point``, ``lineString``, or
+``polygon`` will be used as the geometry. No conversion is done between the coordinates as
+represented in Unify and the coordinates in the feature.
+
+If an attribute named ``bbox`` is available, it will be used as ``bbox``. No conversion is done
+on the value of ``bbox``.
+
+All other attributes will be placed in ``properties``, with no type conversion.
+
+Streaming data access
+---------------------
+
+The ``Dataset`` property ``__geo_features__`` is a generator that allows you to
+stream the records in the dataset as Geospatial features::
+
+  dataset = client.datasets.by_name("my_dataset")
+  for feature in dataset.__geo_features__:
+    do_something(feature)
+

--- a/docs/user-guide/geo.rst
+++ b/docs/user-guide/geo.rst
@@ -40,8 +40,9 @@ attribute, then the value of that attribute will be the value of ``id``. If the 
 composed of multiple attributes, then the value of the ``id`` will be an array with the values
 of the key attributes in order.
 
-The first attribute with type ``RECORD`` containing an attribute named ``point``, ``lineString``, or
-``polygon`` will be used as the geometry. No conversion is done between the coordinates as
+The first attribute with type ``RECORD`` containing an attribute named
+``point``, ``multiPoint``, ``lineString``, ``multiLineString``, ``polygon``, or ``multiPolygon``
+will be used as the geometry. No conversion is done between the coordinates as
 represented in Unify and the coordinates in the feature.
 
 If an attribute named ``bbox`` is available, it will be used as ``bbox``. No conversion is done

--- a/docs/user-guide/geo.rst
+++ b/docs/user-guide/geo.rst
@@ -31,7 +31,7 @@ properties, Unify has a more restricted set of supported types. See https://docs
 The :class:`~tamr_unify_client.models.dataset.resource.Dataset` class supports the
 ``__geo_interface__`` property. This will produce one ``FeatureCollection`` for the entire dataset.
 
-There is a companion iterator ``iterfeatures()`` that returns a generator that allows you to
+There is a companion iterator ``itergeofeatures()`` that returns a generator that allows you to
 stream the records in the dataset as Geospatial features.
 
 To produce a GeoJSON representation of a dataset::
@@ -69,18 +69,18 @@ all geometry attributes other than the first.
 Streaming data access
 ---------------------
 
-The ``Dataset`` method ``iterfeatures()`` returns a generator that allows you to
+The ``Dataset`` method ``itergeofeatures()`` returns a generator that allows you to
 stream the records in the dataset as Geospatial features::
 
   my_dataset = client.datasets.by_name("my_dataset")
-  for feature in my_dataset.iterfeatures():
+  for feature in my_dataset.itergeofeatures():
     do_something(feature)
 
 Note that many packages that consume the Python Geo Interface will be able to consume this
 iterator directly. For example::
 
   from geopandas import GeoDataFrame
-  df = GeoDataFrame.from_features(my_dataset.iterfeatures())
+  df = GeoDataFrame.from_features(my_dataset.itergeofeatures())
 
 This allows construction of a GeoDataFrame directly from the stream of records, without
 materializing the intermediate dataset.

--- a/docs/user-guide/geo.rst
+++ b/docs/user-guide/geo.rst
@@ -23,7 +23,7 @@ be used as the geometry; all other geometry attributes will appear as properties
 The :class:`~tamr_unify_client.models.dataset.resource.Dataset` class supports the
 ``__geo_interface__`` property. This will produce one ``FeatureCollection`` for the entire dataset.
 
-There is a companion property ``__geo_features__`` that returns a generator that allows you to
+There is a companion iterator ``iterfeatures()`` that returns a generator that allows you to
 stream the records in the dataset as Geospatial features.
 
 To produce a GeoJSON representation of a dataset::
@@ -53,10 +53,10 @@ All other attributes will be placed in ``properties``, with no type conversion.
 Streaming data access
 ---------------------
 
-The ``Dataset`` property ``__geo_features__`` is a generator that allows you to
+The ``Dataset`` method ``iterfeatures()`` returns a generator that allows you to
 stream the records in the dataset as Geospatial features::
 
   dataset = client.datasets.by_name("my_dataset")
-  for feature in dataset.__geo_features__:
+  for feature in dataset.iterfeatures():
     do_something(feature)
 

--- a/docs/user-guide/geo.rst
+++ b/docs/user-guide/geo.rst
@@ -56,7 +56,15 @@ Streaming data access
 The ``Dataset`` method ``iterfeatures()`` returns a generator that allows you to
 stream the records in the dataset as Geospatial features::
 
-  dataset = client.datasets.by_name("my_dataset")
-  for feature in dataset.iterfeatures():
+  my_dataset = client.datasets.by_name("my_dataset")
+  for feature in my_dataset.iterfeatures():
     do_something(feature)
 
+Note that many packages that consume the Python Geo Interface will be able to consume this
+iterator directly. For example::
+
+  from geopandas import GeoDataFrame
+  df = GeoDataFrame.from_features(my_dataset.iterfeatures())
+
+This allows construction of a GeoDataFrame directly from the stream of records, without
+materializing the intermediate dataset.

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -107,12 +107,11 @@ class Dataset(BaseResource):
         """
         return {
             "type": "FeatureCollection",
-            "features": [feature for feature in self.__geo_features__],
+            "features": [feature for feature in self.iterfeatures()],
         }
 
-    @property
-    def __geo_features__(self):
-        """A generator of the records in this dataset represented as geospatial features
+    def iterfeatures(self):
+        """Returns an iterator that yields feature dictionaries that comply with __geo_interface__
 
         See https://gist.github.com/sgillies/2217756
 

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -175,7 +175,7 @@ class Dataset(BaseResource):
             "polygon": "Polygon",
             "multiPolygon": "MultiPolygon",
         }
-        if geo_attr in record:
+        if geo_attr and geo_attr in record:
             src_geo = record[geo_attr]
             for unify_attr in conversion.keys():
                 if unify_attr in src_geo and src_geo[unify_attr]:

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -107,7 +107,7 @@ class Dataset(BaseResource):
         """
         return {
             "type": "FeatureCollection",
-            "features": [feature for feature in self.__geo_features__]
+            "features": [feature for feature in self.__geo_features__],
         }
 
     @property
@@ -121,22 +121,29 @@ class Dataset(BaseResource):
         """
         key_attrs = self.key_attribute_names
         if len(key_attrs) == 1:
+
             def key_value(rec):
                 return rec[key_attrs[0]]
+
         else:
+
             def key_value(rec):
                 return [rec[attr] for attr in key_attrs]
 
         # Duck-typing: find all the attributes that look like geometry
         geo_attr_names = {
-            "point", "multiPoint",
-            "lineString", "multiLineString",
-            "polygon", "multiPolygon"
+            "point",
+            "multiPoint",
+            "lineString",
+            "multiLineString",
+            "polygon",
+            "multiPolygon",
         }
         geo_attrs = [
             attr.name
             for attr in self.attributes
-            if "RECORD" == attr.type.base_type and geo_attr_names.intersection(
+            if "RECORD" == attr.type.base_type
+            and geo_attr_names.intersection(
                 {sub_attr.name for sub_attr in attr.type.attributes}
             )
         ]
@@ -158,10 +165,7 @@ class Dataset(BaseResource):
         :param geo_attr: The singular attribute to use as the geometry
         :return: map from str to object
         """
-        feature = {
-            "type": "Feature",
-            "id": key_value(record)
-        }
+        feature = {"type": "Feature", "id": key_value(record)}
         reserved = {"bbox", geo_attr}.union(key_attrs)
         conversion = {
             "point": "Point",
@@ -169,7 +173,7 @@ class Dataset(BaseResource):
             "lineString": "LineString",
             "multiLineString": "MultiLineString",
             "polygon": "Polygon",
-            "multiPolygon": "MultiPolygon"
+            "multiPolygon": "MultiPolygon",
         }
         if geo_attr in record:
             src_geo = record[geo_attr]
@@ -177,7 +181,7 @@ class Dataset(BaseResource):
                 if unify_attr in src_geo and src_geo[unify_attr]:
                     feature["geometry"] = {
                         "type": conversion[unify_attr],
-                        "coordinates": src_geo[unify_attr]
+                        "coordinates": src_geo[unify_attr],
                     }
                     break
         if "bbox" in record:

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -107,10 +107,10 @@ class Dataset(BaseResource):
         """
         return {
             "type": "FeatureCollection",
-            "features": [feature for feature in self.iterfeatures()],
+            "features": [feature for feature in self.itergeofeatures()],
         }
 
-    def iterfeatures(self):
+    def itergeofeatures(self):
         """Returns an iterator that yields feature dictionaries that comply with __geo_interface__
 
         See https://gist.github.com/sgillies/2217756

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -19,16 +19,20 @@ class TestDatasetGeo(TestCase):
         def key_value_single(rec):
             return rec["id"]
 
-        actual = Dataset._record_to_feature(empty_record, key_value_single, ["id"], "geom")
+        actual = Dataset._record_to_feature(
+            empty_record, key_value_single, ["id"], "geom"
+        )
         expected = {"type": "Feature", "id": "1"}
         self.assertEqual(expected, actual)
 
         record_with_point = {"id": "1", "geom": {"point": [1, 1]}}
-        actual = Dataset._record_to_feature(record_with_point, key_value_single, ["id"], "geom")
+        actual = Dataset._record_to_feature(
+            record_with_point, key_value_single, ["id"], "geom"
+        )
         expected = {
             "type": "Feature",
             "id": "1",
-            "geometry": {"type": "Point", "coordinates": [1, 1]}
+            "geometry": {"type": "Point", "coordinates": [1, 1]},
         }
         self.assertEqual(expected, actual)
 
@@ -39,49 +43,63 @@ class TestDatasetGeo(TestCase):
         expected = {
             "type": "Feature",
             "id": "1",
-            "geometry": {"type": "MultiPoint", "coordinates": [[1, 1]]}
+            "geometry": {"type": "MultiPoint", "coordinates": [[1, 1]]},
         }
         self.assertEqual(expected, actual)
 
         record_with_line = {"id": "1", "geom": {"lineString": [[1, 1], [2, 2]]}}
-        actual = Dataset._record_to_feature(record_with_line, key_value_single, ["id"], "geom")
+        actual = Dataset._record_to_feature(
+            record_with_line, key_value_single, ["id"], "geom"
+        )
         expected = {
             "type": "Feature",
             "id": "1",
-            "geometry": {"type": "LineString", "coordinates": [[1, 1], [2, 2]]}
+            "geometry": {"type": "LineString", "coordinates": [[1, 1], [2, 2]]},
         }
         self.assertEqual(expected, actual)
 
-        record_with_multi_line = {"id": "1", "geom": {"multiLineString": [[[1, 1], [2, 2]]]}}
+        record_with_multi_line = {
+            "id": "1",
+            "geom": {"multiLineString": [[[1, 1], [2, 2]]]},
+        }
         actual = Dataset._record_to_feature(
             record_with_multi_line, key_value_single, ["id"], "geom"
         )
         expected = {
             "type": "Feature",
             "id": "1",
-            "geometry": {"type": "MultiLineString", "coordinates": [[[1, 1], [2, 2]]]}
+            "geometry": {"type": "MultiLineString", "coordinates": [[[1, 1], [2, 2]]]},
         }
         self.assertEqual(expected, actual)
 
-        record_with_polygon = {"id": "1", "geom": {"polygon": [[[1, 1], [2, 2], [3, 3]]]}}
-        actual = Dataset._record_to_feature(record_with_polygon, key_value_single, ["id"], "geom")
+        record_with_polygon = {
+            "id": "1",
+            "geom": {"polygon": [[[1, 1], [2, 2], [3, 3]]]},
+        }
+        actual = Dataset._record_to_feature(
+            record_with_polygon, key_value_single, ["id"], "geom"
+        )
         expected = {
             "type": "Feature",
             "id": "1",
-            "geometry": {"type": "Polygon", "coordinates": [[[1, 1], [2, 2], [3, 3]]]}
+            "geometry": {"type": "Polygon", "coordinates": [[[1, 1], [2, 2], [3, 3]]]},
         }
         self.assertEqual(expected, actual)
 
-        record_with_multi_polygon = {"id": "1",
-                                     "geom": {"multiPolygon": [[[[1, 1], [2, 2], [3, 3]]]]}
-                                     }
+        record_with_multi_polygon = {
+            "id": "1",
+            "geom": {"multiPolygon": [[[[1, 1], [2, 2], [3, 3]]]]},
+        }
         actual = Dataset._record_to_feature(
             record_with_multi_polygon, key_value_single, ["id"], "geom"
         )
         expected = {
             "type": "Feature",
             "id": "1",
-            "geometry": {"type": "MultiPolygon", "coordinates": [[[[1, 1], [2, 2], [3, 3]]]]}
+            "geometry": {
+                "type": "MultiPolygon",
+                "coordinates": [[[[1, 1], [2, 2], [3, 3]]]],
+            },
         }
         self.assertEqual(expected, actual)
 
@@ -93,50 +111,54 @@ class TestDatasetGeo(TestCase):
                 "lineString": None,
                 "multiLineString": None,
                 "polygon": None,
-                "multiPolygon": [[[[1, 1], [2, 2], [3, 3]]]]
-            }
+                "multiPolygon": [[[[1, 1], [2, 2], [3, 3]]]],
+            },
         }
-        actual = Dataset._record_to_feature(record_with_full_geo, key_value_single, ["id"], "geom")
+        actual = Dataset._record_to_feature(
+            record_with_full_geo, key_value_single, ["id"], "geom"
+        )
         expected = {
             "type": "Feature",
             "id": "1",
-            "geometry": {"type": "MultiPolygon", "coordinates": [[[[1, 1], [2, 2], [3, 3]]]]}
+            "geometry": {
+                "type": "MultiPolygon",
+                "coordinates": [[[[1, 1], [2, 2], [3, 3]]]],
+            },
         }
         self.assertEqual(expected, actual)
 
         record_with_null_geo = {
             "id": "1",
             "geom": {
-                "point": None, "multiPoint": None,
-                "lineString": None, "multiLineString": None,
-                "polygon": None, "multiPolygon": None
-            }
+                "point": None,
+                "multiPoint": None,
+                "lineString": None,
+                "multiLineString": None,
+                "polygon": None,
+                "multiPolygon": None,
+            },
         }
-        actual = Dataset._record_to_feature(record_with_null_geo, key_value_single, ["id"], "geom")
-        expected = {
-            "type": "Feature",
-            "id": "1"
-        }
+        actual = Dataset._record_to_feature(
+            record_with_null_geo, key_value_single, ["id"], "geom"
+        )
+        expected = {"type": "Feature", "id": "1"}
         self.assertEqual(expected, actual)
 
         record_with_bbox = {"id": "1", "bbox": [[0, 0], [1, 1]]}
-        actual = Dataset._record_to_feature(record_with_bbox, key_value_single, ["id"], "geom")
-        expected = {
-            "type": "Feature",
-            "id": "1",
-            "bbox": [[0, 0], [1, 1]]
-        }
+        actual = Dataset._record_to_feature(
+            record_with_bbox, key_value_single, ["id"], "geom"
+        )
+        expected = {"type": "Feature", "id": "1", "bbox": [[0, 0], [1, 1]]}
         self.assertEqual(expected, actual)
 
         record_with_props = {"id": "1", "p1": "v1", "p2": "v2"}
-        actual = Dataset._record_to_feature(record_with_props, key_value_single, ["id"], "geom")
+        actual = Dataset._record_to_feature(
+            record_with_props, key_value_single, ["id"], "geom"
+        )
         expected = {
             "type": "Feature",
             "id": "1",
-            "properties": {
-                "p1": "v1",
-                "p2": "v2"
-            }
+            "properties": {"p1": "v1", "p2": "v2"},
         }
         self.assertEqual(expected, actual)
 
@@ -145,15 +167,9 @@ class TestDatasetGeo(TestCase):
 
         record_with_composite_key = {"id1": "1", "id2": "2"}
         actual = Dataset._record_to_feature(
-            record_with_composite_key,
-            key_value_composite,
-            ["id1", "id2"],
-            "geom"
+            record_with_composite_key, key_value_composite, ["id1", "id2"], "geom"
         )
-        expected = {
-            "type": "Feature",
-            "id": ["1", "2"]
-        }
+        expected = {"type": "Feature", "id": ["1", "2"]}
         self.assertEqual(expected, actual)
 
         record_with_everything = {
@@ -167,7 +183,7 @@ class TestDatasetGeo(TestCase):
                 "lineString": None,
                 "multiLineString": None,
                 "polygon": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
-                "multiPolygon": None
+                "multiPolygon": None,
             },
             "alternate_geom": {
                 "point": [1, 1],
@@ -175,14 +191,11 @@ class TestDatasetGeo(TestCase):
                 "lineString": None,
                 "multiLineString": None,
                 "polygon": None,
-                "multiPolygon": None
-            }
+                "multiPolygon": None,
+            },
         }
         actual = Dataset._record_to_feature(
-            record_with_everything,
-            key_value_composite,
-            ["id1", "id2"],
-            "geom"
+            record_with_everything, key_value_composite, ["id1", "id2"], "geom"
         )
         expected = {
             "type": "Feature",
@@ -196,12 +209,12 @@ class TestDatasetGeo(TestCase):
                     "lineString": None,
                     "multiLineString": None,
                     "polygon": None,
-                    "multiPolygon": None
-                }
+                    "multiPolygon": None,
+                },
             },
             "geometry": {
                 "type": "Polygon",
-                "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]
+                "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
             },
         }
         self.assertEqual(expected, actual)
@@ -215,19 +228,24 @@ class TestDatasetGeo(TestCase):
         responses.add(responses.GET, attributes_url, json=self._attributes_json)
 
         records_url = f"{dataset_url}/records"
-        responses.add(responses.GET, records_url, body="\n".join(
-            [json.dumps(rec) for rec in self._records_json]
-        ))
+        responses.add(
+            responses.GET,
+            records_url,
+            body="\n".join([json.dumps(rec) for rec in self._records_json]),
+        )
         dataset = self.unify.datasets.by_resource_id("1")
         features = [feature for feature in dataset.__geo_features__]
         self.assertEqual(6, len(features))
         self.assertSetEqual(
             {
-                "point", "multiPoint",
-                "lineString", "multiLineString",
-                "polygon", "multiPolygon"
+                "point",
+                "multiPoint",
+                "lineString",
+                "multiLineString",
+                "polygon",
+                "multiPolygon",
             },
-            {feature["id"] for feature in features}
+            {feature["id"] for feature in features},
         )
 
     @responses.activate
@@ -239,19 +257,24 @@ class TestDatasetGeo(TestCase):
         responses.add(responses.GET, attributes_url, json=self._attributes_json)
 
         records_url = f"{dataset_url}/records"
-        responses.add(responses.GET, records_url, body="\n".join(
-            [json.dumps(rec) for rec in self._records_json]
-        ))
+        responses.add(
+            responses.GET,
+            records_url,
+            body="\n".join([json.dumps(rec) for rec in self._records_json]),
+        )
         dataset = self.unify.datasets.by_resource_id("1")
         fc = dataset.__geo_interface__
         self.assertEqual("FeatureCollection", fc["type"])
         self.assertSetEqual(
             {
-                "point", "multiPoint",
-                "lineString", "multiLineString",
-                "polygon", "multiPolygon"
+                "point",
+                "multiPoint",
+                "lineString",
+                "multiLineString",
+                "polygon",
+                "multiPolygon",
             },
-            {feature["id"] for feature in fc["features"]}
+            {feature["id"] for feature in fc["features"]},
         )
 
     _dataset_json = {
@@ -387,7 +410,7 @@ class TestDatasetGeo(TestCase):
                             "attributes": [],
                         },
                         "isNullable": True,
-                    }
+                    },
                 ],
             },
             "isNullable": False,
@@ -398,10 +421,18 @@ class TestDatasetGeo(TestCase):
         {"id": "point", "geom": {"point": [1, 1]}},
         {"id": "multiPoint", "geom": {"multiPoint": [[1, 1], [2, 2]]}},
         {"id": "lineString", "geom": {"lineString": [[1, 1], [2, 2]]}},
-        {"id": "multiLineString",
-         "geom": {"multiLineString": [[[1, 1], [2, 2]], [[3, 3], [4, 4]]]}},
+        {
+            "id": "multiLineString",
+            "geom": {"multiLineString": [[[1, 1], [2, 2]], [[3, 3], [4, 4]]]},
+        },
         {"id": "polygon", "geom": {"polygon": [[[1, 1], [2, 2], [3, 3], [1, 1]]]}},
-        {"id": "multiPolygon", "geom": {
-            "multiPolygon": [[[[1, 1], [2, 2], [3, 3], [1, 1]]],
-                             [[[4, 4], [5, 5], [6, 6], [4, 4]]]]}}
+        {
+            "id": "multiPolygon",
+            "geom": {
+                "multiPolygon": [
+                    [[[1, 1], [2, 2], [3, 3], [1, 1]]],
+                    [[[4, 4], [5, 5], [6, 6], [4, 4]]],
+                ]
+            },
+        },
     ]

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -219,6 +219,13 @@ class TestDatasetGeo(TestCase):
         }
         self.assertEqual(expected, actual)
 
+        record_without_geo = {"id": "1", "prop1": "val1"}
+        actual = Dataset._record_to_feature(
+            record_without_geo, key_value_single, ["id"], None
+        )
+        expected = {"type": "Feature", "id": "1", "properties": {"prop1": "val1"}}
+        self.assertEqual(expected, actual)
+
     @responses.activate
     def test_geo_features(self):
         dataset_url = f"http://localhost:9100/api/versioned/v1/datasets/1"

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -1,4 +1,4 @@
-import simplejson as json
+import json
 from unittest import TestCase
 
 import responses

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -241,7 +241,7 @@ class TestDatasetGeo(TestCase):
             body="\n".join([json.dumps(rec) for rec in self._records_json]),
         )
         dataset = self.unify.datasets.by_resource_id("1")
-        features = [feature for feature in dataset.__geo_features__]
+        features = [feature for feature in dataset.iterfeatures()]
         self.assertEqual(6, len(features))
         self.assertSetEqual(
             {

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -241,7 +241,7 @@ class TestDatasetGeo(TestCase):
             body="\n".join([json.dumps(rec) for rec in self._records_json]),
         )
         dataset = self.unify.datasets.by_resource_id("1")
-        features = [feature for feature in dataset.iterfeatures()]
+        features = [feature for feature in dataset.itergeofeatures()]
         self.assertEqual(6, len(features))
         self.assertSetEqual(
             {

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -1,0 +1,286 @@
+import simplejson as json
+from unittest import TestCase
+
+import responses
+
+from tamr_unify_client import Client
+from tamr_unify_client.auth import UsernamePasswordAuth
+from tamr_unify_client.models.dataset.resource import Dataset
+
+
+class TestDatasetGeo(TestCase):
+    def setUp(self):
+        auth = UsernamePasswordAuth("username", "password")
+        self.unify = Client(auth)
+
+    def test_record_to_feature(self):
+        empty_record = {"id": "1"}
+
+        def key_value_single(rec):
+            return rec["id"]
+
+        actual = Dataset._record_to_feature(empty_record, key_value_single, ["id"], "geom")
+        expected = {"type": "Feature", "id": "1"}
+        self.assertEqual(expected, actual)
+
+        record_with_point = {"id": "1", "geom": {"point": [1, 1]}}
+        actual = Dataset._record_to_feature(record_with_point, key_value_single, ["id"], "geom")
+        expected = {
+            "type": "Feature",
+            "id": "1",
+            "geometry": {"type": "Point", "coordinates": [1, 1]}
+        }
+        self.assertEqual(expected, actual)
+
+        record_with_line = {"id": "1", "geom": {"lineString": [[1, 1], [2, 2]]}}
+        actual = Dataset._record_to_feature(record_with_line, key_value_single, ["id"], "geom")
+        expected = {
+            "type": "Feature",
+            "id": "1",
+            "geometry": {"type": "LineString", "coordinates": [[1, 1], [2, 2]]}
+        }
+        self.assertEqual(expected, actual)
+
+        record_with_polygon = {"id": "1", "geom": {"polygon": [[[1, 1], [2, 2], [3, 3]]]}}
+        actual = Dataset._record_to_feature(record_with_polygon, key_value_single, ["id"], "geom")
+        expected = {
+            "type": "Feature",
+            "id": "1",
+            "geometry": {"type": "Polygon", "coordinates": [[[1, 1], [2, 2], [3, 3]]]}
+        }
+        self.assertEqual(expected, actual)
+
+        record_with_full_geo = {
+            "id": "1",
+            "geom": {
+                "point": None,
+                "lineString": None,
+                "polygon": [[[1, 1], [2, 2], [3, 3]]]
+            }
+        }
+        actual = Dataset._record_to_feature(record_with_full_geo, key_value_single, ["id"], "geom")
+        expected = {
+            "type": "Feature",
+            "id": "1",
+            "geometry": {"type": "Polygon", "coordinates": [[[1, 1], [2, 2], [3, 3]]]}
+        }
+        self.assertEqual(expected, actual)
+
+        record_with_null_geo = {
+            "id": "1",
+            "geom": {"point": None, "lineString": None, "polygon": None}
+        }
+        actual = Dataset._record_to_feature(record_with_null_geo, key_value_single, ["id"], "geom")
+        expected = {
+            "type": "Feature",
+            "id": "1",
+            "geometry": None
+        }
+        self.assertEqual(expected, actual)
+
+        record_with_bbox = {"id": "1", "bbox": [[0, 0], [1, 1]]}
+        actual = Dataset._record_to_feature(record_with_bbox, key_value_single, ["id"], "geom")
+        expected = {
+            "type": "Feature",
+            "id": "1",
+            "bbox": [[0, 0], [1, 1]]
+        }
+        self.assertEqual(expected, actual)
+
+        record_with_props = {"id": "1", "p1": "v1", "p2": "v2"}
+        actual = Dataset._record_to_feature(record_with_props, key_value_single, ["id"], "geom")
+        expected = {
+            "type": "Feature",
+            "id": "1",
+            "properties": {
+                "p1": "v1",
+                "p2": "v2"
+            }
+        }
+        self.assertEqual(expected, actual)
+
+        def key_value_composite(rec):
+            return [rec[v] for v in ["id1", "id2"]]
+
+        record_with_composite_key = {"id1": "1", "id2": "2"}
+        actual = Dataset._record_to_feature(
+            record_with_composite_key,
+            key_value_composite,
+            ["id1", "id2"],
+            "geom"
+        )
+        expected = {
+            "type": "Feature",
+            "id": ["1", "2"]
+        }
+        self.assertEqual(expected, actual)
+
+        record_with_everything = {
+            "id1": "1",
+            "id2": "2",
+            "bbox": [[0, 0], [1, 1]],
+            "name": "record with everything",
+            "geom": {
+                "point": None,
+                "lineString": None,
+                "polygon": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]
+            },
+            "alternate_geom": {
+                "point": [1, 1],
+                "lineString": None,
+                "polygon": None
+            }
+        }
+        actual = Dataset._record_to_feature(
+            record_with_everything,
+            key_value_composite,
+            ["id1", "id2"],
+            "geom"
+        )
+        expected = {
+            "type": "Feature",
+            "id": ["1", "2"],
+            "bbox": [[0, 0], [1, 1]],
+            "properties": {
+                "name": "record with everything",
+                "alternate_geom": {
+                    "point": [1, 1],
+                    "lineString": None,
+                    "polygon": None
+                }
+            },
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]
+            },
+        }
+        self.assertEqual(expected, actual)
+
+    @responses.activate
+    def test_geo_features(self):
+        dataset_url = f"http://localhost:9100/api/versioned/v1/datasets/1"
+        responses.add(responses.GET, dataset_url, json=self._dataset_json)
+
+        attributes_url = f"{dataset_url}/attributes"
+        responses.add(responses.GET, attributes_url, json=self._attributes_json)
+
+        records_url = f"{dataset_url}/records"
+        responses.add(responses.GET, records_url, body="\n".join(
+            [json.dumps(rec) for rec in self._records_json]
+        ))
+        dataset = self.unify.datasets.by_resource_id("1")
+        features = [feature for feature in dataset.__geo_features__]
+        self.assertEqual(3, len(features))
+        self.assertSetEqual(
+            {"point", "lineString", "polygon"},
+            {feature["id"] for feature in features}
+        )
+
+    @responses.activate
+    def test_geo_interface(self):
+        dataset_url = f"http://localhost:9100/api/versioned/v1/datasets/1"
+        responses.add(responses.GET, dataset_url, json=self._dataset_json)
+
+        attributes_url = f"{dataset_url}/attributes"
+        responses.add(responses.GET, attributes_url, json=self._attributes_json)
+
+        records_url = f"{dataset_url}/records"
+        responses.add(responses.GET, records_url, body="\n".join(
+            [json.dumps(rec) for rec in self._records_json]
+        ))
+        dataset = self.unify.datasets.by_resource_id("1")
+        fc = dataset.__geo_interface__
+        self.assertEqual("FeatureCollection", fc["type"])
+        self.assertSetEqual(
+            {"point", "lineString", "polygon"},
+            {feature["id"] for feature in fc["features"]}
+        )
+
+    _dataset_json = {
+        "id": "unify://unified-data/v1/datasets/1",
+        "externalId": "number 1",
+        "name": "dataset 1 name",
+        "description": "dataset 1 description",
+        "version": "dataset 1 version",
+        "keyAttributeNames": ["id"],
+        "tags": [],
+        "created": {
+            "username": "admin",
+            "time": "2018-09-10T16:06:20.636Z",
+            "version": "dataset 1 created version",
+        },
+        "lastModified": {
+            "username": "admin",
+            "time": "2018-09-10T16:06:20.851Z",
+            "version": "dataset 1 modified version",
+        },
+        "relativeId": "datasets/1",
+        "upstreamDatasetIds": [],
+    }
+
+    _attributes_json = [
+        {
+            "name": "id",
+            "description": "primary key",
+            "type": {"baseType": "STRING", "attributes": []},
+            "isNullable": False,
+        },
+        {
+            "name": "geom",
+            "description": "Geospatial geometry",
+            "type": {
+                "baseType": "RECORD",
+                "attributes": [
+                    {
+                        "name": "point",
+                        "type": {
+                            "baseType": "ARRAY",
+                            "innerType": {"baseType": "DOUBLE", "attributes": []},
+                            "attributes": [],
+                        },
+                        "isNullable": True,
+                    },
+                    {
+                        "name": "lineString",
+                        "type": {
+                            "baseType": "ARRAY",
+                            "innerType": {
+                                "baseType": "ARRAY",
+                                "innerType": {"baseType": "DOUBLE", "attributes": []},
+                                "attributes": [],
+                            },
+                            "attributes": [],
+                        },
+                        "isNullable": True,
+                    },
+                    {
+                        "name": "polygon",
+                        "type": {
+                            "baseType": "ARRAY",
+                            "innerType": {
+                                "baseType": "ARRAY",
+                                "innerType": {
+                                    "baseType": "ARRAY",
+                                    "innerType": {
+                                        "baseType": "DOUBLE",
+                                        "attributes": [],
+                                    },
+                                    "attributes": [],
+                                },
+                                "attributes": [],
+                            },
+                            "attributes": [],
+                        },
+                        "isNullable": True,
+                    },
+                ],
+            },
+            "isNullable": False,
+        },
+    ]
+
+    _records_json = [
+        {"id": "point", "geom": {"point": [1, 1]}},
+        {"id": "lineString", "geom": {"lineString": [[1, 1], [2, 2]]}},
+        {"id": "polygon", "geom": {"polygon": [[[1, 1], [2, 2], [3, 3], [1, 1]]]}}
+    ]


### PR DESCRIPTION
# ↪️ Pull Request

Provide Python Geo Interface on Dataset
Fix #98

## 💻 Examples

To produce a GeoJSON representation of a dataset::
```
  dataset = client.datasets.by_name("my_dataset")
  with open("my_dataset.json", "w") as f:
    json.dump(dataset.__geo_interface__, f)
```
To stream the records of a dataset as Geospatial features::
```
  dataset = client.datasets.by_name("my_dataset")
  for feature in dataset.iterfeatures():
    do_something(feature)
```
And this is super spiffy:
```
>>> import geopandas
>>> df=geopandas.GeoDataFrame.from_features(unify.datasets.by_name('my_dataset'))
>>> df.head()
  BASE_ELEV ELEV_GL ELEV_SL TOP_GL TOP_SL    TYPE                                           geometry last_edited_date last_edited_user
0      38.8    55.1      94   62.2  101.1  BORDER  POLYGON ((-71.1522084419519 42.3745215835176, ...       2018-03-26           JAMERO
1      43.5    25.5      69   37.3   80.9  BORDER  POLYGON ((-71.1514340605336 42.3744385428379, ...       2018-03-26           JAMERO
2      41.8    23.9    65.7   37.4   79.2  BORDER  POLYGON ((-71.1516949801055 42.3743460611468, ...       2018-03-26           JAMERO
3      39.9    22.5    62.4     39   78.9  BORDER  POLYGON ((-71.15185254313759 42.3743409491551,...       2018-03-26           JAMERO
4      45.7    25.7    71.4   37.9   83.6  BORDER  POLYGON ((-71.1512542097983 42.3745055126458, ...       2018-03-26           JAMERO
```
## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
