### PR TITLE
fix update_records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.5.0-dev
   **NEW FEATURES**
   - [#94](https://github.com/Datatamer/unify-client-python/issues/94) Add access to Attributes of a Dataset
-  - [#103](https://github.com/Datatamer/unify-client-python/issues/103) Dataset `update_records` improvements
+  - [#103](https://github.com/Datatamer/unify-client-python/issues/103) Dataset `update_records` now returns the JSON response body for the underlying `POST datasets/{id}:updateRecords` call
   - [#98](https://github.com/Datatamer/unify-client-python/issues/98) Add `__geo_interface__` to Dataset
   - [#100](https://github.com/Datatamer/unify-client-python/issues/100) Add `from_geo_features` to Dataset
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.0-dev
   **NEW FEATURES**
   - [#94](https://github.com/Datatamer/unify-client-python/issues/94) Add access to Attributes of a Dataset
+  - [#103](https://github.com/Datatamer/unify-client-python/issues/103) Dataset `update_records` improvements
 
 ## 0.4.0
   **BREAKING CHANGES**

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -62,14 +62,20 @@ class Dataset(BaseResource):
         :returns: JSON response body from server.
         :rtype: :py:class:`dict`
         """
+
         def _stringify_updates(updates):
             for update in updates:
-                yield f'{update}'.encode('utf-8')
+                yield f"{update}".encode("utf-8")
 
-        return self.client.post(
-            self.api_path + ':updateRecords',
-            headers={'Content-Encoding': "utf-8"},
-            data=_stringify_updates(records)).successful().json()
+        return (
+            self.client.post(
+                self.api_path + ":updateRecords",
+                headers={"Content-Encoding": "utf-8"},
+                data=_stringify_updates(records),
+            )
+            .successful()
+            .json()
+        )
 
     def refresh(self, **options):
         """Brings dataset up-to-date if needed, taking whatever actions are required.

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -59,23 +59,17 @@ class Dataset(BaseResource):
 
         :param records: Each record should be formatted as specified in the `Public Docs for Dataset updates <https://docs.tamr.com/reference#modify-a-datasets-records>`_.
         :type records: iterable[dict]
-        :returns: JSON response body from server. 
+        :returns: JSON response body from server.
         :rtype: :py:class:`dict`
         """
-
         def _stringify_updates(updates):
             for update in updates:
                 yield f"{update}\n".encode("utf-8")
 
-        return (
-            self.client.post(
-                self.api_path + ":updateRecords",
-                headers={"Content-Encoding": "utf-8"},
-                data=_stringify_updates(records),
-            )
-            .successful()
-            .json()
-        )
+        return self.client.post(
+            self.api_path + ":updateRecords",
+            headers={"Content-Encoding": "utf-8"},
+            data=_stringify_updates(records)).successful().json()
 
     def refresh(self, **options):
         """Brings dataset up-to-date if needed, taking whatever actions are required.

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -59,15 +59,23 @@ class Dataset(BaseResource):
 
         :param records: Each record should be formatted as specified in the `Public Docs for Dataset updates <https://docs.tamr.com/reference#modify-a-datasets-records>`_.
         :type records: iterable[dict]
+        :returns: JSON response body from server. 
+        :rtype: :py:class:`dict`
         """
+
         def _stringify_updates(updates):
             for update in updates:
                 yield f"{update}\n".encode("utf-8")
 
-        return self.client.post(
-            self.api_path + ":updateRecords",
-            headers={"Content-Encoding": "utf-8"},
-            data=_stringify_updates(records)).successful().json()
+        return (
+            self.client.post(
+                self.api_path + ":updateRecords",
+                headers={"Content-Encoding": "utf-8"},
+                data=_stringify_updates(records),
+            )
+            .successful()
+            .json()
+        )
 
     def refresh(self, **options):
         """Brings dataset up-to-date if needed, taking whatever actions are required.

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -60,8 +60,9 @@ class Dataset(BaseResource):
         :param records: Each record should be formatted as specified in the `Public Docs for Dataset updates <https://docs.tamr.com/reference#modify-a-datasets-records>`_.
         :type records: iterable[dict]
         """
-        for update in updates:
-            yield f"{update}\n".encode("utf-8")
+        def _stringify_updates(updates):
+            for update in updates:
+                yield f"{update}\n".encode("utf-8")
 
         return self.client.post(
             self.api_path + ":updateRecords",

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -64,11 +64,11 @@ class Dataset(BaseResource):
         """
         def _stringify_updates(updates):
             for update in updates:
-                yield f"{update}\n".encode("utf-8")
+                yield f'{update}'.encode('utf-8')
 
         return self.client.post(
-            self.api_path + ":updateRecords",
-            headers={"Content-Encoding": "utf-8"},
+            self.api_path + ':updateRecords',
+            headers={'Content-Encoding': "utf-8"},
             data=_stringify_updates(records)).successful().json()
 
     def refresh(self, **options):

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -59,9 +59,14 @@ class Dataset(BaseResource):
 
         :param records: Each record should be formatted as specified in the `Public Docs for Dataset updates <https://docs.tamr.com/reference#modify-a-datasets-records>`_.
         :type records: list[dict]
-        """
-        body = "\n".join([json.dumps(r) for r in records])
-        self.client.post(self.api_path + ":updateRecords", data=body)
+            """
+        for update in updates:
+            yield f"{update}\n".encode("utf-8")
+
+        return self.client.post(
+            self.api_path + ":updateRecords",
+            headers={"Content-Encoding": "utf-8"},
+            data=_stringify_updates(records)).successful().json()
 
     def refresh(self, **options):
         """Brings dataset up-to-date if needed, taking whatever actions are required.

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -479,7 +479,7 @@ class TestDatasetGeo(TestCase):
             },
         ]
         expected = "\n".join(json.dumps(update) for update in updates)
-        actual = snoop["payload"]
+        actual = list(snoop["payload"])
         self.assertEqual(expected, actual)
 
         class NotAFeatureCollection:
@@ -538,7 +538,7 @@ class TestDatasetGeo(TestCase):
             },
         ]
         expected = "\n".join(json.dumps(update) for update in updates)
-        actual = snoop["payload"]
+        actual = list(snoop["payload"])
         self.assertEqual(expected, actual)
 
     _dataset_json = {

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -478,8 +478,8 @@ class TestDatasetGeo(TestCase):
                 "record": {"geom": {"point": [1, 1]}, "id": "2"},
             },
         ]
-        expected = [json.dumps(update).encode('utf8') for update in updates]
-        actual = list(snoop["payload"])
+        expected = [json.dumps(update).replace('"', "'") for update in updates]
+        actual = [a.decode("utf8") for a in list(snoop["payload"])]
         self.assertEqual(expected, actual)
 
         class NotAFeatureCollection:
@@ -490,7 +490,7 @@ class TestDatasetGeo(TestCase):
         snoop["payload"] = None
         nafc = NotAFeatureCollection()
         dataset.from_geo_features(nafc)
-        actual = snoop["payload"]
+        actual = [a.decode("utf8") for a in list(snoop["payload"])]
         self.assertEqual(expected, actual)
 
     @responses.activate
@@ -537,9 +537,9 @@ class TestDatasetGeo(TestCase):
                 "record": {"geom": {"point": [1, 1]}, "id1": "2", "id2": "b"},
             },
         ]
-        expected = [json.dumps(update).encode('utf8') for update in updates]
+        expected = [json.dumps(update).replace('"', "'") for update in updates]
         self.maxDiff = None
-        actual = list(snoop["payload"])
+        actual = [a.decode("utf8") for a in list(snoop["payload"])]
         self.assertEqual(expected, actual)
 
     _dataset_json = {

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from functools import partial
 import json
 from unittest import TestCase
+import ast
 
 import responses
 
@@ -478,8 +479,8 @@ class TestDatasetGeo(TestCase):
                 "record": {"geom": {"point": [1, 1]}, "id": "2"},
             },
         ]
-        expected = [json.dumps(update).replace('"', "'") for update in updates]
-        actual = [a.decode("utf8") for a in list(snoop["payload"])]
+        expected = updates
+        actual = [ast.literal_eval(a.decode("utf8")) for a in (snoop["payload"])]
         self.assertEqual(expected, actual)
 
         class NotAFeatureCollection:
@@ -490,7 +491,7 @@ class TestDatasetGeo(TestCase):
         snoop["payload"] = None
         nafc = NotAFeatureCollection()
         dataset.from_geo_features(nafc)
-        actual = [a.decode("utf8") for a in list(snoop["payload"])]
+        actual = [ast.literal_eval(a.decode("utf8")) for a in (snoop["payload"])]
         self.assertEqual(expected, actual)
 
     @responses.activate
@@ -537,9 +538,8 @@ class TestDatasetGeo(TestCase):
                 "record": {"geom": {"point": [1, 1]}, "id1": "2", "id2": "b"},
             },
         ]
-        expected = [json.dumps(update).replace('"', "'") for update in updates]
-        self.maxDiff = None
-        actual = [a.decode("utf8") for a in list(snoop["payload"])]
+        expected = updates
+        actual = [ast.literal_eval(a.decode("utf8")) for a in (snoop["payload"])]
         self.assertEqual(expected, actual)
 
     _dataset_json = {

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -1,8 +1,8 @@
+import ast
 from copy import deepcopy
 from functools import partial
 import json
 from unittest import TestCase
-import ast
 
 import responses
 

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -478,7 +478,7 @@ class TestDatasetGeo(TestCase):
                 "record": {"geom": {"point": [1, 1]}, "id": "2"},
             },
         ]
-        expected = "\n".join(json.dumps(update) for update in updates)
+        expected = [json.dumps(update).encode('utf8') for update in updates]
         actual = list(snoop["payload"])
         self.assertEqual(expected, actual)
 
@@ -537,7 +537,8 @@ class TestDatasetGeo(TestCase):
                 "record": {"geom": {"point": [1, 1]}, "id1": "2", "id2": "b"},
             },
         ]
-        expected = "\n".join(json.dumps(update) for update in updates)
+        expected = [json.dumps(update).encode('utf8') for update in updates]
+        self.maxDiff = None
         actual = list(snoop["payload"])
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Resolves #101 and #90 

## 💻 Examples

Allows clients to use update_records method without materializing the streaming source/ database into one large string. 

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
