### PR TITLE
Fix 118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   - [#98](https://github.com/Datatamer/unify-client-python/issues/98) Add `__geo_interface__` to Dataset
   - [#100](https://github.com/Datatamer/unify-client-python/issues/100) Add `from_geo_features` to Dataset
 
+  **BUG FIXES**
+  - [#118](https://github.com/Datatamer/unify-client-python/issues/118) Fix JSON sent for Dataset.update_records
+
 ## 0.4.0
   **BREAKING CHANGES**
   - [#61](https://github.com/Datatamer/unify-client-python/issues/61) `data` field renamed to `_data` (private).

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -65,7 +65,7 @@ class Dataset(BaseResource):
 
         def _stringify_updates(updates):
             for update in updates:
-                yield f"{update}".encode("utf-8")
+                yield json.dumps(update).encode("utf-8")
 
         return (
             self.client.post(

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -1,4 +1,3 @@
-import ast
 from copy import deepcopy
 from functools import partial
 import json
@@ -480,7 +479,7 @@ class TestDatasetGeo(TestCase):
             },
         ]
         expected = updates
-        actual = [ast.literal_eval(a.decode("utf8")) for a in (snoop["payload"])]
+        actual = [json.loads(item) for item in snoop["payload"]]
         self.assertEqual(expected, actual)
 
         class NotAFeatureCollection:
@@ -491,7 +490,7 @@ class TestDatasetGeo(TestCase):
         snoop["payload"] = None
         nafc = NotAFeatureCollection()
         dataset.from_geo_features(nafc)
-        actual = [ast.literal_eval(a.decode("utf8")) for a in (snoop["payload"])]
+        actual = [json.loads(item) for item in snoop["payload"]]
         self.assertEqual(expected, actual)
 
     @responses.activate
@@ -539,7 +538,7 @@ class TestDatasetGeo(TestCase):
             },
         ]
         expected = updates
-        actual = [ast.literal_eval(a.decode("utf8")) for a in (snoop["payload"])]
+        actual = [json.loads(item) for item in snoop["payload"]]
         self.assertEqual(expected, actual)
 
     _dataset_json = {


### PR DESCRIPTION
# ↪️ Pull Request

Fix #118 : serialize Dataset updates as JSON, not Python

## 💻 Examples

See #118 

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
