### PR TITLE
Add a commit_interval option to Dataset.update_records

### DIFF
--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -81,6 +81,7 @@ class Dataset(BaseResource):
         updates = peekable(_stringify_updates(records))
         try:
             while True:
+                # Create a session here to take advantage of keep alive
                 result = self.client.post(
                     self.api_path + ":updateRecords",
                     headers={"Content-Encoding": "utf-8"},


### PR DESCRIPTION
# ↪️ Pull Request

When sending data to Unify, there are timeouts all over the place that interrupt sending data. This PR adds `commit_interval` to `Dataset.update_records`; when a commit_interval is specified, the update request is completed after that many records, allowing the server to commit, and the update stream is picked up in a new update request to the server.

## 💻 Examples

`dataset.update_records(updates, commit_interval=10000)`

## ✔️ PR Todo

- [ ] Added/updated testing for this change
- [ ] Included links to related issues/PRs
- [ ] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
