### PR TITLE
Add support for fetching Estimated Pair Counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - [#100](https://github.com/Datatamer/unify-client-python/issues/100) Add `from_geo_features` to Dataset
   - [#116](https://github.com/Datatamer/unify-client-python/issues/116) Add support for associating a dataset with a project
   - [#109](https://github.com/Datatamer/unify-client-python/issues/109) Add support for profiling datasets
+  - [#114](https://github.com/Datatamer/unify-client-python/issues/114) Add support for generate pairs estimate
   
   **BUG FIXES**
   - [#118](https://github.com/Datatamer/unify-client-python/issues/118) Fix JSON sent for Dataset.update_records

--- a/docs/developer-interface.rst
+++ b/docs/developer-interface.rst
@@ -81,6 +81,11 @@ Project
 .. autoclass:: tamr_unify_client.models.project.mastering.MasteringProject
   :members:
 
+----
+
+.. autoclass:: tamr_unify_client.models.project.estimated_pair_counts.EstimatedPairCounts
+  :members:
+
 Projects
 --------
 

--- a/tamr_unify_client/models/project/estimated_pair_counts.py
+++ b/tamr_unify_client/models/project/estimated_pair_counts.py
@@ -20,13 +20,13 @@ class EstimatedPairCounts(BaseResource):
     def total_estimate(self) -> dict:
         """The total number of estimated candidate pairs and generated pairs for the model across all clauses.
 
-        :return: A dictionary containing candidate pairs and estimated pairs mapped to their corresponding estimated counts
-                For example:
-                {
-                    "candidatePairCount": "54321",
-                    "generatedPairCount": "12345"
-                }
-        :rtype: dict[str, int]
+        :return: A dictionary containing candidate pairs and estimated pairs mapped to their corresponding estimated counts.
+            For example:\n
+            {\n
+                "candidatePairCount": "54321",\n
+                "generatedPairCount": "12345"\n
+            }
+        :rtype: dict[str, str]
         """
         return self._data.get("totalEstimate")
 
@@ -34,19 +34,19 @@ class EstimatedPairCounts(BaseResource):
     def clause_estimates(self) -> dict:
         """The estimated candidate pair count and generated pair count for each clause in the model.
 
-        :return: A dictionary containing each clause name mapped to a dictionary containing the corresponding estimated candidate and generated pair counts
-                For example:
-                  {
-                    "Clause1": {
-                      "candidatePairCount": "321",
-                      "generatedPairCount": "123"
-                    },
-                    "Clause2": {
-                      "candidatePairCount": "654",
-                      "generatedPairCount": "456"
-                    }
-                  }
-        :rtype: dict[str, dict[str, int]]
+        :return: A dictionary containing each clause name mapped to a dictionary containing the corresponding estimated candidate and generated pair counts.
+            For example:\n
+            {\n
+                "Clause1": {\n
+                    "candidatePairCount": "321",\n
+                    "generatedPairCount": "123"\n
+                },\n
+                "Clause2": {\n
+                    "candidatePairCount": "654",\n
+                    "generatedPairCount": "456"\n
+                }\n
+            }
+        :rtype: dict[str, dict[str, str]]
         """
         return self._data.get("clauseEstimates")
 

--- a/tamr_unify_client/models/project/estimated_pair_counts.py
+++ b/tamr_unify_client/models/project/estimated_pair_counts.py
@@ -21,7 +21,7 @@ class EstimatedPairCounts(BaseResource):
         """The total number of estimated candidate pairs and generated pairs for the model across all clauses.
 
         :return: A dictionary containing candidate pairs and estimated pairs mapped to their corresponding estimated counts
-                For example: 
+                For example:
                 {
                     "candidatePairCount": "54321",
                     "generatedPairCount": "12345"

--- a/tamr_unify_client/models/project/estimated_pair_counts.py
+++ b/tamr_unify_client/models/project/estimated_pair_counts.py
@@ -1,0 +1,42 @@
+from tamr_unify_client.models.base_resource import BaseResource
+
+
+class EstimatedPairCounts(BaseResource):
+    """Estimated Pair Counts info for Mastering Project"""
+
+    @classmethod
+    def from_json(cls, client, resource_json, api_path=None) -> "EstimatedPairCounts":
+        return super().from_data(client, resource_json, api_path)
+
+    @property
+    def is_up_to_date(self) -> bool:
+        """Whether the associated dataset is up to date.
+
+        :type: bool
+        """
+        return self._data.get("isUpToDate")
+
+    @property
+    def total_estimate(self) -> dict:
+        """Info about when profile info was generated.
+
+        :type: dict
+        """
+        return self._data.get("totalEstimate")
+
+    @property
+    def clause_estimates(self) -> dict:
+        """Info about when profile info was generated.
+
+        :type: dict
+        """
+        return self._data.get("clauseEstimates")
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"up_to_date={self.is_up_to_date!r}, "
+            f"total_estimate={self.total_estimate!r}, "
+            f"clause_estimates={self.clause_estimates!r})"
+        )

--- a/tamr_unify_client/models/project/estimated_pair_counts.py
+++ b/tamr_unify_client/models/project/estimated_pair_counts.py
@@ -20,7 +20,12 @@ class EstimatedPairCounts(BaseResource):
     def total_estimate(self) -> dict:
         """The total number of estimated candidate pairs and generated pairs for the model across all clauses.
 
-        :return: Candidate pairs and estimated pairs with corresponding estimated counts
+        :return: A dictionary containing candidate pairs and estimated pairs mapped to their corresponding estimated counts
+                For example: 
+                {
+                    "candidatePairCount": "54321",
+                    "generatedPairCount": "12345"
+                }
         :rtype: dict[str, int]
         """
         return self._data.get("totalEstimate")
@@ -29,8 +34,19 @@ class EstimatedPairCounts(BaseResource):
     def clause_estimates(self) -> dict:
         """The estimated candidate pair count and generated pair count for each clause in the model.
 
-        :return: Each clause with corresponding estimated candidate pair count and generated pair count.
-        :rtype: dict[str, [dict[str, int]]
+        :return: A dictionary containing each clause name mapped to a dictionary containing the corresponding estimated candidate and generated pair counts
+                For example:
+                  {
+                    "Clause1": {
+                      "candidatePairCount": "321",
+                      "generatedPairCount": "123"
+                    },
+                    "Clause2": {
+                      "candidatePairCount": "654",
+                      "generatedPairCount": "456"
+                    }
+                  }
+        :rtype: dict[str, dict[str, int]]
         """
         return self._data.get("clauseEstimates")
 

--- a/tamr_unify_client/models/project/estimated_pair_counts.py
+++ b/tamr_unify_client/models/project/estimated_pair_counts.py
@@ -10,7 +10,7 @@ class EstimatedPairCounts(BaseResource):
 
     @property
     def is_up_to_date(self) -> bool:
-        """Whether the associated dataset is up to date.
+        """Whether an estimate pairs job has been run since the last edit to the binning model.
 
         :type: bool
         """
@@ -18,7 +18,7 @@ class EstimatedPairCounts(BaseResource):
 
     @property
     def total_estimate(self) -> dict:
-        """Info about when profile info was generated.
+        """The total number of estimated candidate pairs and generated pairs for the model across all clauses.
 
         :type: dict
         """
@@ -26,7 +26,7 @@ class EstimatedPairCounts(BaseResource):
 
     @property
     def clause_estimates(self) -> dict:
-        """Info about when profile info was generated.
+        """The clause name, candidate pair count, and generated pair count for each clause in the model.
 
         :type: dict
         """

--- a/tamr_unify_client/models/project/estimated_pair_counts.py
+++ b/tamr_unify_client/models/project/estimated_pair_counts.py
@@ -12,7 +12,7 @@ class EstimatedPairCounts(BaseResource):
     def is_up_to_date(self) -> bool:
         """Whether an estimate pairs job has been run since the last edit to the binning model.
 
-        :type: bool
+        :rtype: bool
         """
         return self._data.get("isUpToDate")
 
@@ -20,15 +20,17 @@ class EstimatedPairCounts(BaseResource):
     def total_estimate(self) -> dict:
         """The total number of estimated candidate pairs and generated pairs for the model across all clauses.
 
-        :type: dict
+        :return: Candidate pairs and estimated pairs with corresponding estimated counts
+        :rtype: dict[str, int]
         """
         return self._data.get("totalEstimate")
 
     @property
     def clause_estimates(self) -> dict:
-        """The clause name, candidate pair count, and generated pair count for each clause in the model.
+        """The estimated candidate pair count and generated pair count for each clause in the model.
 
-        :type: dict
+        :return: Each clause with corresponding estimated candidate pair count and generated pair count.
+        :rtype: dict[str, [dict[str, int]]
         """
         return self._data.get("clauseEstimates")
 

--- a/tamr_unify_client/models/project/mastering.py
+++ b/tamr_unify_client/models/project/mastering.py
@@ -1,5 +1,6 @@
 from tamr_unify_client.models.dataset.resource import Dataset
 from tamr_unify_client.models.machine_learning_model import MachineLearningModel
+from tamr_unify_client.models.project.estimated_pair_counts import EstimatedPairCounts
 from tamr_unify_client.models.project.resource import Project
 
 
@@ -75,5 +76,17 @@ class MasteringProject(Project):
         """
         alias = self.api_path + "/publishedClusters"
         return Dataset(self.client, None, alias)
+
+    def estimate_pairs(self):
+        """Returns up to date estimated pair counts for a mastering project, re-estimating if not up to date.
+
+        :param ``**options``: Options passed to underlying :class:`~tamr_unify_client.models.operation.Operation` .
+        :return: Pairs Estimate information.
+        :rtype: :class:`~tamr_unify_client.models.project.estimated_pair_counts`
+        """
+        alias = self.api_path + "/estimatedPairCounts"
+        estimate_json = self.client.get(alias).successful().json()
+        info = EstimatedPairCounts.from_json(self.client, estimate_json, api_path=alias)
+        return info
 
     # super.__repr__ is sufficient

--- a/tamr_unify_client/models/project/mastering.py
+++ b/tamr_unify_client/models/project/mastering.py
@@ -78,9 +78,8 @@ class MasteringProject(Project):
         return Dataset(self.client, None, alias)
 
     def estimate_pairs(self):
-        """Returns up to date estimated pair counts for a mastering project, re-estimating if not up to date.
+        """Returns pair estimate information for a mastering project
 
-        :param ``**options``: Options passed to underlying :class:`~tamr_unify_client.models.operation.Operation` .
         :return: Pairs Estimate information.
         :rtype: :class:`~tamr_unify_client.models.project.estimated_pair_counts`
         """

--- a/tests/mock_api/test_continuous_mastering.py
+++ b/tests/mock_api/test_continuous_mastering.py
@@ -41,7 +41,9 @@ def test_continuous_mastering():
     op = project.published_clusters().refresh(poll_interval_seconds=0)
     assert op.succeeded()
 
-    estimate_url = f"http://localhost:9100/api/versioned/v1/projects/1/estimatedPairCounts"
+    estimate_url = (
+        f"http://localhost:9100/api/versioned/v1/projects/1/estimatedPairCounts"
+    )
     estimate_json = {"isUpToDate": True}
     responses.add(responses.GET, estimate_url, json=estimate_json)
 

--- a/tests/mock_api/test_continuous_mastering.py
+++ b/tests/mock_api/test_continuous_mastering.py
@@ -45,25 +45,13 @@ def test_continuous_mastering():
         f"http://localhost:9100/api/versioned/v1/projects/1/estimatedPairCounts"
     )
     estimate_json = {
-      "isUpToDate": "true",
-      "totalEstimate": {
-        "candidatePairCount": "200",
-        "generatedPairCount": "100"
-      },
-      "clauseEstimates": {
-        "clause1": {
-          "candidatePairCount": "50",
-          "generatedPairCount": "25"
+        "isUpToDate": "true",
+        "totalEstimate": {"candidatePairCount": "200", "generatedPairCount": "100"},
+        "clauseEstimates": {
+            "clause1": {"candidatePairCount": "50", "generatedPairCount": "25"},
+            "clause2": {"candidatePairCount": "50", "generatedPairCount": "25"},
+            "clause3": {"candidatePairCount": "100", "generatedPairCount": "50"},
         },
-        "clause2": {
-          "candidatePairCount": "50",
-          "generatedPairCount": "25"
-        },
-        "clause3": {
-          "candidatePairCount": "100",
-          "generatedPairCount": "50"
-        }
-      }
     }
     responses.add(responses.GET, estimate_url, json=estimate_json)
 
@@ -75,5 +63,3 @@ def test_continuous_mastering():
 
     clause1 = project.estimate_pairs().clause_estimates["clause1"]
     assert clause1["generatedPairCount"] == "25"
-
-

--- a/tests/mock_api/test_continuous_mastering.py
+++ b/tests/mock_api/test_continuous_mastering.py
@@ -44,8 +44,36 @@ def test_continuous_mastering():
     estimate_url = (
         f"http://localhost:9100/api/versioned/v1/projects/1/estimatedPairCounts"
     )
-    estimate_json = {"isUpToDate": True}
+    estimate_json = {
+      "isUpToDate": "true",
+      "totalEstimate": {
+        "candidatePairCount": "200",
+        "generatedPairCount": "100"
+      },
+      "clauseEstimates": {
+        "clause1": {
+          "candidatePairCount": "50",
+          "generatedPairCount": "25"
+        },
+        "clause2": {
+          "candidatePairCount": "50",
+          "generatedPairCount": "25"
+        },
+        "clause3": {
+          "candidatePairCount": "100",
+          "generatedPairCount": "50"
+        }
+      }
+    }
     responses.add(responses.GET, estimate_url, json=estimate_json)
 
     status = project.estimate_pairs().is_up_to_date
     assert status
+
+    candidate = project.estimate_pairs().total_estimate["candidatePairCount"]
+    assert candidate == "200"
+
+    clause1 = project.estimate_pairs().clause_estimates["clause1"]
+    assert clause1["generatedPairCount"] == "25"
+
+

--- a/tests/mock_api/test_continuous_mastering.py
+++ b/tests/mock_api/test_continuous_mastering.py
@@ -1,5 +1,7 @@
 import os
 
+import responses
+
 from tamr_unify_client import Client
 from tamr_unify_client.auth import UsernamePasswordAuth
 from .utils import mock_api
@@ -38,3 +40,10 @@ def test_continuous_mastering():
 
     op = project.published_clusters().refresh(poll_interval_seconds=0)
     assert op.succeeded()
+
+    estimate_url = f"http://localhost:9100/api/versioned/v1/projects/1/estimatedPairCounts"
+    estimate_json = {"isUpToDate": True}
+    responses.add(responses.GET, estimate_url, json=estimate_json)
+
+    status = project.estimate_pairs().is_up_to_date
+    assert status


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->
# ↪️ Pull Request

Adds support for fetching Estimated Pair Counts, addressing #114
1. Create new class called EstimatedPairCounts
2. New method in mastering.py to fetch estimate 

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
