### PR TITLE
Support for data with NULL geo attribute in Dataset.itergeofeatures 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.6.0-dev
+  **BUG FIXES**
+  - [#140](https://github.com/Datatamer/unify-client-python/issues/140) Dataset `itergeofeatures` now supports data with geo attribute NULL
 
 ## 0.5.0
   **NEW FEATURES**

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -252,14 +252,19 @@ class Dataset(BaseResource):
         reserved = {"bbox", geo_attr}.union(key_attrs)
         if geo_attr and geo_attr in record:
             src_geo = record[geo_attr]
-            for unify_attr in Dataset._geo_attr_names():
-                if unify_attr in src_geo and src_geo[unify_attr]:
-                    feature["geometry"] = {
-                        # Convert e.g. multiLineString -> MultiLineString
-                        "type": unify_attr[0].upper() + unify_attr[1:],
-                        "coordinates": src_geo[unify_attr],
-                    }
-                    break
+            if src_geo:
+                for unify_attr in Dataset._geo_attr_names():
+                    if unify_attr in src_geo and src_geo[unify_attr]:
+                        feature["geometry"] = {
+                            # Convert e.g. multiLineString -> MultiLineString
+                            "type": unify_attr[0].upper() + unify_attr[1:],
+                            "coordinates": src_geo[unify_attr],
+                        }
+                        break
+                    else:
+                        feature["geometry"] = None
+            else:
+                feature["geometry"] = None
         if "bbox" in record:
             feature["bbox"] = record["bbox"]
         non_reserved = set(record.keys()).difference(reserved)

--- a/tests/unit/test_dataset_geo.py
+++ b/tests/unit/test_dataset_geo.py
@@ -143,7 +143,7 @@ class TestDatasetGeo(TestCase):
         actual = Dataset._record_to_feature(
             record_with_null_geo, key_value_single, ["id"], "geom"
         )
-        expected = {"type": "Feature", "id": "1"}
+        expected = {"geometry": None, "type": "Feature", "id": "1"}
         self.assertEqual(expected, actual)
 
         record_with_bbox = {"id": "1", "bbox": [[0, 0], [1, 1]]}


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
Fixes #140 
## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
