### PR TITLE
Fix #156 - Dataset profile can be out of date.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 0.7.0-dev
+  **BREAKING CHANGES**
+  - [#156](https://github.com/Datatamer/unify-client-python/issues/156) Fetch Dataset profile, even if out of date.
+
   **NEW FEATURES**
   - [#65] (https://github.com/Datatamer/unify-client-python/issues/65) Fetches published clusters with data represented as a dataset.
 

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -104,27 +104,37 @@ class Dataset(BaseResource):
         op = Operation.from_json(self.client, op_json)
         return op.apply_options(**options)
 
-    def profile(self, **options):
-        """Returns up to date profile information for a dataset, re-profiling if not up to date.
+    def profile(self):
+        """Returns profile information for a dataset.
+
+        If profile information has not been generated, call create_profile() first.
+        If the returned profile information is out-of-date, you can call refresh() on the returned
+        object to bring it up-to-date.
 
         :param ``**options``: Options passed to underlying :class:`~tamr_unify_client.models.operation.Operation` .
         :return: Dataset Profile information.
         :rtype: :class:`~tamr_unify_client.models.dataset_status.DatasetProfile`
         """
-
         profile_json = self.client.get(self.api_path + "/profile").successful().json()
-        info = DatasetProfile.from_json(
+        return DatasetProfile.from_json(
             self.client, profile_json, api_path=self.api_path + "/profile"
         )
-        if info.is_up_to_date:
-            return info
-        else:
-            op_json = (
-                self.client.post(self.api_path + "/profile:refresh").successful().json()
-            )
-            op = Operation.from_json(self.client, op_json)
-            op.apply_options(**options)
-            return self.profile()
+
+    def create_profile(self, **options):
+        """Create a profile for this dataset.
+
+        If a profile already exists, the existing profile will be brought
+        up to date.
+
+        :param ``**options``: Options passed to underlying :class:`~tamr_unify_client.models.operation.Operation` .
+            See :func:`~tamr_unify_client.models.operation.Operation.apply_options` .
+        :return: the operation to create the profile.
+        """
+        op_json = (
+            self.client.post(self.api_path + "/profile:refresh").successful().json()
+        )
+        op = Operation.from_json(self.client, op_json)
+        return op.apply_options(**options)
 
     def records(self):
         """Stream this dataset's records as Python dictionaries.

--- a/tamr_unify_client/models/dataset_profile.py
+++ b/tamr_unify_client/models/dataset_profile.py
@@ -1,4 +1,5 @@
 from tamr_unify_client.models.base_resource import BaseResource
+from tamr_unify_client.models.operation import Operation
 
 
 class DatasetProfile(BaseResource):
@@ -64,6 +65,20 @@ class DatasetProfile(BaseResource):
         """
         return self._data.get("attributeProfiles")
 
+    def refresh(self, **options):
+        """Updates the dataset profile if needed.
+
+        The dataset profile is updated on the server; you will need to call
+        :func:`~tamr_unify_client.models.dataset.resource.Dataset.profile`
+        to retrieve the updated profile.
+
+        :param ``**options``: Options passed to underlying :class:`~tamr_unify_client.models.operation.Operation` .
+            See :func:`~tamr_unify_client.models.operation.Operation.apply_options` .
+        """
+        op_json = self.client.post(self.api_path + ":refresh").successful().json()
+        op = Operation.from_json(self.client, op_json)
+        return op.apply_options(**options)
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__module__}."
@@ -71,7 +86,7 @@ class DatasetProfile(BaseResource):
             f"relative_id={self.relative_id!r}, "
             f"dataset_name={self.dataset_name!r}, "
             f"relative_dataset_id={self.relative_dataset_id!r}, "
-            f"up_to_date={self.is_up_to_date!r}, "
+            f"is_up_to_date={self.is_up_to_date!r}, "
             f"profiled_data_version={self.profiled_data_version!r}, "
             f"profiled_at={self.profiled_at!r}, "
             f"simple_metrics={self.simple_metrics!r})"

--- a/tests/unit/test_dataset_profile.py
+++ b/tests/unit/test_dataset_profile.py
@@ -1,36 +1,123 @@
-import json
+from unittest import TestCase
 
 import responses
 
 from tamr_unify_client import Client
 from tamr_unify_client.auth import UsernamePasswordAuth
 
-profile_json1 = {
-    "datasetName": "ds3",
-    "relativeDatasetId": "v1/datasets/3",
-    "isUpToDate": "false",
-    "profiledDataVersion": "3",
-    "profiledAt": {
-        "username": "system",
-        "time": "2019-06-05T14:23:25.860Z",
-        "version": "46",
-    },
-    "simpleMetrics": [{"metricName": "rowCount", "metricValue": "1999"}],
-}
 
+class TestDatasetProfile(TestCase):
+    @responses.activate
+    def test_dataset_profile(self):
+        auth = UsernamePasswordAuth("username", "password")
+        client = Client(auth)
 
-@responses.activate
-def test_dataset_profile():
-    dataset_id = "3"
-    dataset_url = f"http://localhost:9100/api/versioned/v1/datasets/{dataset_id}"
-    profile_url = f"{dataset_url}/profile"
-    profile_refresh_url = f"{profile_url}:refresh"
-    responses.add(responses.GET, dataset_url, json={})
-    responses.add(responses.GET, profile_url, json=profile_json1)
-    responses.add(responses.POST, profile_refresh_url, json=[], status=204)
-    auth = UsernamePasswordAuth("username", "password")
-    unify = Client(auth)
+        dataset_id = "3"
+        dataset_url = f"{client.protocol}://{client.host}:{client.port}/api/versioned/v1/datasets/{dataset_id}"
+        profile_url = f"{dataset_url}/profile"
+        responses.add(responses.GET, dataset_url, json={})
+        responses.add(responses.GET, profile_url, json=self.profile_stale)
 
-    dataset = unify.datasets.by_resource_id(dataset_id)
-    profile = dataset.profile()
-    assert profile._data == profile_json1
+        dataset = client.datasets.by_resource_id(dataset_id)
+        profile = dataset.profile()
+        self.assertEqual(self.profile_stale["datasetName"], profile.dataset_name)
+        self.assertEqual(
+            self.profile_stale["relativeDatasetId"], profile.relative_dataset_id
+        )
+        self.assertEqual(self.profile_stale["isUpToDate"], profile.is_up_to_date)
+        self.assertEqual(
+            self.profile_stale["profiledDataVersion"], profile.profiled_data_version
+        )
+        self.assertEqual(self.profile_stale["profiledAt"], profile.profiled_at)
+        self.assertEqual(self.profile_stale["simpleMetrics"], profile.simple_metrics)
+        self.assertEqual(
+            self.profile_stale["attributeProfiles"], profile.attribute_profiles
+        )
+
+    @responses.activate
+    def test_profile_refresh(self):
+        auth = UsernamePasswordAuth("username", "password")
+        client = Client(auth)
+
+        dataset_id = "3"
+        dataset_url = f"{client.protocol}://{client.host}:{client.port}/api/versioned/v1/datasets/{dataset_id}"
+        profile_url = f"{dataset_url}/profile"
+        profile_refresh_url = f"{profile_url}:refresh"
+        responses.add(responses.GET, dataset_url, json={})
+        responses.add(responses.GET, profile_url, json=self.profile_stale)
+        responses.add(
+            responses.POST, profile_refresh_url, json=self.operation_succeeded
+        )
+
+        dataset = client.datasets.by_resource_id(dataset_id)
+        profile = dataset.profile()
+        op = profile.refresh()
+        self.assertTrue(op.succeeded())
+
+    @responses.activate
+    def test_profile_create(self):
+        auth = UsernamePasswordAuth("username", "password")
+        client = Client(auth)
+
+        dataset_id = "3"
+        dataset_url = f"{client.protocol}://{client.host}:{client.port}/api/versioned/v1/datasets/{dataset_id}"
+        profile_url = f"{dataset_url}/profile"
+        profile_refresh_url = f"{profile_url}:refresh"
+        responses.add(responses.GET, dataset_url, json={})
+        # We need to ensure that, when creating the profile,
+        # nothing ever tries to access the (non-existent) profile.
+        responses.add(responses.GET, profile_url, status=404)
+        responses.add(
+            responses.POST, profile_refresh_url, json=self.operation_succeeded
+        )
+
+        dataset = client.datasets.by_resource_id(dataset_id)
+        op = dataset.create_profile()
+        self.assertTrue(op.succeeded())
+
+    profile_stale = {
+        "datasetName": "ds3",
+        "relativeDatasetId": "v1/datasets/3",
+        "isUpToDate": False,
+        "profiledDataVersion": "3",
+        "profiledAt": {
+            "username": "system",
+            "time": "2019-06-05T14:23:25.860Z",
+            "version": "46",
+        },
+        "simpleMetrics": [{"metricName": "rowCount", "metricValue": "1999"}],
+        "attributeProfiles": [
+            {
+                "attributeName": "attribute1",
+                "simpleMetrics": [
+                    {"metricName": "distinctValueCount", "metricValue": "1999"}
+                ],
+                "mostFrequentValues": [
+                    {"value": "value1", "frequency": "1999", "percentFrequency": 1.0}
+                ],
+            }
+        ],
+    }
+
+    operation_succeeded = {
+        "id": "1",
+        "type": "SPARK",
+        "description": "Synthetic Operation",
+        "status": {
+            "state": "SUCCEEDED",
+            "startTime": "2018-12-14T19:34:00.273Z",
+            "endTime": "2018-12-14T19:34:14.573Z",
+            "message": "",
+        },
+        "created": {
+            "username": "admin",
+            "time": "2018-12-14T19:33:50.538Z",
+            "version": "390",
+        },
+        "lastModified": {
+            "username": "system",
+            "time": "2018-12-14T19:34:15.200Z",
+            "version": "399",
+        },
+        "relativeId": "operations/1",
+    }


### PR DESCRIPTION
# ↪️ Pull Request

Fix #156 - Fetch DatasetProfile, even if out of date.

This changes the behavior of Dataset.profile() - it no longer refreshes the profile.
This adds DatasetProfile.refresh() to replace the previous behavior.
This adds Dataset.create_profile() to create a profile if none exists.

## 💻 Examples

```python
        auth = UsernamePasswordAuth("username", "password")
        client = Client(auth)

        dataset = client.datasets.by_resource_id("3")
        op = dataset.create_profile()
        assert op.successful()
        profile = dataset.profile()
        if not profile.is_up_to_date:
                op = profile.refresh()
                assert op.successful()
```


## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
