### PR TITLE
Fix #161 - DatasetCollection.create() and ProjectCollection.create() don't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## 0.7.0-dev
   **BREAKING CHANGES**
   - [#156](https://github.com/Datatamer/unify-client-python/issues/156) Fetch Dataset profile, even if out of date.
+  - [#161](https://github.com/Datatamer/unify-client-python/issues/161) Move `create_attribute` from Dataset to AttributeCollection 
 
   **NEW FEATURES**
-  - [#65] (https://github.com/Datatamer/unify-client-python/issues/65) Fetches published clusters with data represented as a dataset.
+  - [#65](https://github.com/Datatamer/unify-client-python/issues/65) Fetches published clusters with data represented as a dataset.
+
+  **BUG FIXES**
+  - [#161](https://github.com/Datatamer/unify-client-python/issues/161) DatasetCollection.create() and ProjectCollection.create() don't work
 
 ## 0.6.0
   **BREAKING CHANGES**

--- a/tamr_unify_client/models/attribute/collection.py
+++ b/tamr_unify_client/models/attribute/collection.py
@@ -100,7 +100,6 @@ class AttributeCollection(BaseCollection):
         :returns: The created Attribute
         :rtype: :class:`~tamr_unify_client.models.attribute.resource.Attribute`
         """
-        from tamr_unify_client.models.attribute.resource import Attribute
         data = self.client.post(self.api_path, json=creation_spec).successful().json()
         alias = self.api_path + "/" + creation_spec["name"]
         return Attribute.from_json(self.client, data, alias)

--- a/tamr_unify_client/models/attribute/collection.py
+++ b/tamr_unify_client/models/attribute/collection.py
@@ -91,4 +91,16 @@ class AttributeCollection(BaseCollection):
                 return attribute
         raise KeyError(f"No attribute found with name: {attribute_name}")
 
+    def create(self, creation_spec):
+        """
+        Create an Attribute in this collection
+
+        :param creation_spec: Attribute creation specification should be formatted as specified in the `Public Docs for adding an Attribute <https://docs.tamr.com/reference#add-attributes>`_.
+        :type creation_spec: dict[str, str]
+        :returns: The created Attribute
+        :rtype: :class:`~tamr_unify_client.models.attribute.resource.Attribute`
+        """
+        data = self.client.post(self.api_path, json=creation_spec).successful().json()
+        return Attribute.from_json(self.client, data)
+
     # super.__repr__ is sufficient

--- a/tamr_unify_client/models/attribute/collection.py
+++ b/tamr_unify_client/models/attribute/collection.py
@@ -100,7 +100,9 @@ class AttributeCollection(BaseCollection):
         :returns: The created Attribute
         :rtype: :class:`~tamr_unify_client.models.attribute.resource.Attribute`
         """
+        from tamr_unify_client.models.attribute.resource import Attribute
         data = self.client.post(self.api_path, json=creation_spec).successful().json()
-        return Attribute.from_json(self.client, data)
+        alias = self.api_path + "/" + creation_spec["name"]
+        return Attribute.from_json(self.client, data, alias)
 
     # super.__repr__ is sufficient

--- a/tamr_unify_client/models/dataset/collection.py
+++ b/tamr_unify_client/models/dataset/collection.py
@@ -87,6 +87,6 @@ class DatasetCollection(BaseCollection):
         :rtype: :class:`~tamr_unify_client.models.dataset.resource.Dataset`
         """
         data = self.client.post(self.api_path, json=creation_spec).successful().json()
-        return Dataset.from_json(self, data)
+        return Dataset.from_json(self.client, data)
 
     # super.__repr__ is sufficient

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -55,23 +55,6 @@ class Dataset(BaseResource):
         resource_json = self.client.get(alias).successful().json()
         return AttributeCollection.from_json(self.client, resource_json, alias)
 
-    def create_attribute(self, attribute_creation_spec):
-        """Create an Attribute in Unify
-
-        :param attribute_creation_spec: the name and type (and optional description) of the attribute to create, formatted as described in the `Public Docs for Adding an Attribute <https://docs.tamr.com/reference#add-attributes>`_.
-        :type attribute_creation_spec: dict[str, object]
-        :return: the created Attribute
-        """
-        from tamr_unify_client.models.attribute.resource import Attribute
-
-        data = (
-            self.client.post(self.attributes.api_path, json=attribute_creation_spec)
-            .successful()
-            .json()
-        )
-        alias = self.attributes.api_path + "/" + attribute_creation_spec["name"]
-        return Attribute(self.client, data, alias)
-
     def update_records(self, records):
         """Send a batch of record creations/updates/deletions to this dataset.
 

--- a/tamr_unify_client/models/project/collection.py
+++ b/tamr_unify_client/models/project/collection.py
@@ -72,6 +72,6 @@ class ProjectCollection(BaseCollection):
         :rtype: :class:`~tamr_unify_client.models.project.resource.Project`
         """
         data = self.client.post(self.api_path, json=creation_spec).successful().json()
-        return Project.from_json(self, data)
+        return Project.from_json(self.client, data)
 
     # super.__repr__ is sufficient

--- a/tests/unit/test_dataset_attributes.py
+++ b/tests/unit/test_dataset_attributes.py
@@ -33,7 +33,7 @@ def test_dataset_attributes():
     )
 
     dataset = unify.datasets.by_resource_id("1")
-    create = dataset.create_attribute(attribute_creation_spec)
+    create = dataset.attributes.create(attribute_creation_spec)
     created = dataset.attributes.by_name("myAttribute")
 
     assert (create.relative_id) == (created.relative_id)


### PR DESCRIPTION
# ↪️ Pull Request

Fix #161 - DatasetCollection.create() and ProjectCollection.create() don't work.

* Fix `DatasetCollection.create()` so that it can successfully create a dataset.
* Fix `ProjectCollection.create()` so that it can successfully create a project.
* Move `Dataset.create_attribute()` to `AttributeCollection.create()`, and ensure that it can successfully create an attribute.

## 💻 Examples

```
client = Client(...)
project_config = { "name": "MyProject", "type": "DEDUP", "unifiedDatasetName": "MyProject_unified_dataset"}
project = client.projects.create(project_config)
dataset_config = { "name": "MyDataset", "keyAttributeNames": ["id"] }
dataset = client.datasets.create(dataset_config)
attribute_config = { "name": "MyAttribute", "type": {"baseType": "STRING"}}
attribute = dataset.attributes.create(attribute_config)
```

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
