### PR TITLE
Feature Request #154: support for Published_clusters_with_data

### DIFF
--- a/tamr_unify_client/models/project/mastering.py
+++ b/tamr_unify_client/models/project/mastering.py
@@ -110,4 +110,14 @@ class MasteringProject(Project):
         name = unified_dataset.name + "_dedup_clusters_with_data"
         return self.client.datasets.by_name(name)
 
-    # super.__repr__ is sufficient
+        # super.__repr__ is sufficient
+
+    def published_clusters_with_data(self):
+        """Project's unified dataset with associated clusters.
+        :returns: The published clusters with data represented as a dataset
+        :rtype :class `~tamr_unify_client.models.dataset.resource.Dataset`
+        """
+
+        unified_dataset = self.unified_dataset()
+        name = unified_dataset.name + "_dedup_published_clusters_with_data"
+        return self.client.datasets.by_name(name)

--- a/tests/mock_api/test_continuous_mastering.py
+++ b/tests/mock_api/test_continuous_mastering.py
@@ -1,10 +1,11 @@
 import os
 
 import responses
+from tests.mock_api.utils import mock_api
 
 from tamr_unify_client import Client
 from tamr_unify_client.auth import UsernamePasswordAuth
-from .utils import mock_api
+
 
 basedir = os.path.dirname(__file__)
 response_log_path = os.path.join(

--- a/tests/unit/test_published_clusters_with_data.py
+++ b/tests/unit/test_published_clusters_with_data.py
@@ -1,0 +1,51 @@
+import responses
+
+from tamr_unify_client import Client
+from tamr_unify_client.auth import UsernamePasswordAuth
+
+
+@responses.activate
+def test_published_clusters_with_data():
+    project_config = {
+        "name": "Project 1",
+        "description": "Mastering Project",
+        "type": "DEDUP",
+        "unifiedDatasetName": "Project_1_unified_dataset",
+        "externalId": "Project1",
+        "resourceId": "1",
+    }
+
+    unified_dataset_json = {
+        "id": "unify://unified-data/v1/datasets/8",
+        "name": "Project_1_unified_dataset",
+        "version": "10",
+        "relativeId": "datasets/8",
+        "externalId": "Project_1_unified_dataset",
+    }
+
+    pcwd_json = {
+        "externalId": "1",
+        "id": "unify://unified-data/v1/datasets/36",
+        "name": "Project_1_unified_dataset_dedup_published_clusters_with_data",
+        "relativeId": "datasets/36",
+        "version": "251",
+    }
+
+    datasets_json = [pcwd_json]
+
+    unify = Client(UsernamePasswordAuth("username", "password"))
+
+    project_id = "1"
+
+    project_url = f"http://localhost:9100/api/versioned/v1/projects/{project_id}"
+    unified_dataset_url = (
+        f"http://localhost:9100/api/versioned/v1/projects/{project_id}/unifiedDataset"
+    )
+    datasets_url = f"http://localhost:9100/api/versioned/v1/datasets"
+
+    responses.add(responses.GET, project_url, json=project_config)
+    responses.add(responses.GET, unified_dataset_url, json=unified_dataset_json)
+    responses.add(responses.GET, datasets_url, json=datasets_json)
+    project = unify.projects.by_resource_id(project_id)
+    actual_pcwd_dataset = project.as_mastering().published_clusters_with_data()
+    assert actual_pcwd_dataset.name == pcwd_json["name"]


### PR DESCRIPTION
# ↪️ Feature Request #154: support for Published_clusters_with_data

<!---
-created published_clusters_with_data method that returns a project's published clusters with data (in the form of a dataset) for unify_client_python using API 
-Added testing for this change (see test_published_clusters_with_data.py)  
-->

## 💻 Examples

-created published_clusters_with_data method that returns a project's published clusters with data (in the form of a dataset) for unify_client_python using API 
-Added testing for this change (see test_published_clusters_with_data.py)  


## ✔️ PR Todo

