### PR TITLE
Fix 165: speed up `Dataset.itergeofeatures()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 
   **NEW FEATURES**
   - [#65](https://github.com/Datatamer/unify-client-python/issues/65) Fetches published clusters with data represented as a dataset.
+  - [#165](https://github.com/Datatamer/unify-client-python/issues/165) Add `geo_attr` parameter to `Dataset.itergeofeatures()` and `Dataset.from_geo_features()`
 
   **BUG FIXES**
   - [#148](https://github.com/Datatamer/unify-client-python/issues/148) Fix null geo, id and absent id bug for geospatial datasets. 
   - [#161](https://github.com/Datatamer/unify-client-python/issues/161) DatasetCollection.create() and ProjectCollection.create() don't work
+  - [#165](https://github.com/Datatamer/unify-client-python/issues/165) Dataset.itergeofeatures() is too slow
 
 ## 0.6.0
   **BREAKING CHANGES**

--- a/docs/user-guide/geo.rst
+++ b/docs/user-guide/geo.rst
@@ -40,12 +40,21 @@ To produce a GeoJSON representation of a dataset::
   with open("my_dataset.json", "w") as f:
     json.dump(dataset.__geo_interface__, f)
 
+
+By default, ``itergeofeatures()`` will use the first dataset attribute with geometry type to fill
+in the feature geometry. You can override this by specifying the geometry attribute to use in the
+``geo_attr`` parameter to ``itergeofeatures``.
+
 ``Dataset`` can also be updated from a feature collection that supports the Python Geo Interface::
 
   import geopandas
   geodataframe = geopandas.GeoDataFrame(...)
   dataset = client.dataset.by_name("my_dataset")
   dataset.from_geo_features(geodataframe)
+
+By default the features' geometries will be placed into the first dataset attribute with geometry
+type. You can override this by specifying the geometry attribute to use in the ``geo_attr``
+parameter to ``from_geo_features``.
 
 Rules for converting from Unify records to Geospatial Features
 ------------------------------------------------------------------

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -205,8 +205,10 @@ class Dataset(BaseResource):
             def key_value(rec):
                 return [rec[attr] for attr in key_attrs]
 
+        geo_attr = self._geo_attr
+
         for record in self.records():
-            yield self._record_to_feature(record, key_value, key_attrs, self._geo_attr)
+            yield self._record_to_feature(record, key_value, key_attrs, geo_attr)
 
     @property
     def _geo_attr(self):

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -140,7 +140,7 @@ class Dataset(BaseResource):
             self.client, status_json, api_path=self.api_path + "/status"
         )
 
-    def from_geo_features(self, features):
+    def from_geo_features(self, features, geo_attr=None):
         """Upsert this dataset from a geospatial FeatureCollection or iterable of Features.
 
         `features` can be:
@@ -153,7 +153,13 @@ class Dataset(BaseResource):
 
         See: geopandas.GeoDataFrame.from_features()
 
+        If geo_attr is provided, then the named Unify attribute will be used for the geometry.
+        If geo_attr is not provided, then the first attribute on the dataset with geometry type
+        will be used for the geometry.
+
         :param features: geospatial features
+        :param geo_attr: (optional) name of the Unify attribute to use for the feature's geometry
+        :type geo_attr: str
         """
         if hasattr(features, "__geo_interface__"):
             features = features.__geo_interface__
@@ -166,8 +172,11 @@ class Dataset(BaseResource):
         else:
             record_id = "compositeRecordId"
 
+        if geo_attr is None:
+            geo_attr = self._geo_attr
+
         self.update_records(
-            self._features_to_updates(features, record_id, key_attrs, self._geo_attr)
+            self._features_to_updates(features, record_id, key_attrs, geo_attr)
         )
 
     @property
@@ -186,11 +195,13 @@ class Dataset(BaseResource):
             "features": [feature for feature in self.itergeofeatures()],
         }
 
-    def itergeofeatures(self):
+    def itergeofeatures(self, geo_attr=None):
         """Returns an iterator that yields feature dictionaries that comply with __geo_interface__
 
         See https://gist.github.com/sgillies/2217756
 
+        :param geo_attr: (optional) name of the Unify attribute to use for the feature's geometry
+        :type geo_attr: str
         :return: stream of features
         :rtype: Python generator yielding :py:class:`dict[str, object]`
         """
@@ -205,7 +216,8 @@ class Dataset(BaseResource):
             def key_value(rec):
                 return [rec[attr] for attr in key_attrs]
 
-        geo_attr = self._geo_attr
+        if geo_attr is None:
+            geo_attr = self._geo_attr
 
         for record in self.records():
             yield self._record_to_feature(record, key_value, key_attrs, geo_attr)


### PR DESCRIPTION
# ↪️ Pull Request

Fix #165 - speed up `Dataset.itergeofeatures()`

Also adds optional `geo_attr` in a couple places it was missing.

## 💻 Examples

```
dataset = client.datasets.by_resource_id('1')
for feature in dataset.itergeofeatures():
    do_something_with(feature)
```

Also:
```
for feature in dataset.itergeofeatures(geo_attr="my_geometry_attribute"):
    do_something_with(feature)
```

Also also:
```
featureCollection = get_feature_collection()
dataset.from_geo_features(geo_attr="my_geometry_attribute")
```
## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
