### PR TITLE
Attribute collection and type changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 0.8.0-dev
+  **BREAKING CHANGES**
+  - [#175](https://github.com/Datatamer/unify-client-python/issues/175) `AttributeCollection` no longer has a `from_json` method or a `data` parameter in its constructor
+  - `AttributeType` no longer inherits from `BaseResource` (no API path), removing its `from_json` method and `relative_id` property
+  - The type of `AttributeType`'s `attributes` property is now a `list` of `SubAttribute`s, which are identical to `Attribute`s except they lack an API path
+
   **NEW FEATURES**
   - [#174](https://github.com/Datatamer/unify-client-python/issues/174) Get and create taxonomy categories
   - [#182](https://github.com/Datatamer/unify-client-python/issues/182) Add the ability to refresh estimated pair counts.

--- a/docs/developer-interface.rst
+++ b/docs/developer-interface.rst
@@ -54,6 +54,8 @@ Attribute
 
 .. autoclass:: tamr_unify_client.models.attribute.resource.Attribute
 
+.. autoclass:: tamr_unify_client.models.attribute.subattribute.SubAttribute
+
 Attribute Type
 --------------
 

--- a/tamr_unify_client/models/attribute/collection.py
+++ b/tamr_unify_client/models/attribute/collection.py
@@ -7,22 +7,13 @@ class AttributeCollection(BaseCollection):
 
     :param client: Client for API call delegation.
     :type client: :class:`~tamr_unify_client.Client`
-    :param data: JSON data representing this resource
-    :type data: dict
     :param api_path: API path used to access this collection.
         E.g. ``"datasets/1/attributes"``.
     :type api_path: str
     """
 
-    def __init__(self, client, data, api_path):
+    def __init__(self, client, api_path):
         super().__init__(client, api_path)
-        self._data = data
-
-    @classmethod
-    def from_json(cls, client, data, api_path):
-        # BaseCollection doesn't really implement from_json / from_data
-        # but we pretend it does.
-        return AttributeCollection(client, data, api_path)
 
     def by_resource_id(self, resource_id):
         """Retrieve an attribute by resource ID.
@@ -73,7 +64,8 @@ class AttributeCollection(BaseCollection):
             >>> for attribute in collection: # implicit
             >>>     do_stuff(attribute)
         """
-        for resource_json in self._data:
+        data = self.client.get(self.api_path).successful().json()
+        for resource_json in data:
             alias = self.api_path + "/" + resource_json["name"]
             yield Attribute.from_json(self.client, resource_json, alias)
 

--- a/tamr_unify_client/models/attribute/resource.py
+++ b/tamr_unify_client/models/attribute/resource.py
@@ -44,9 +44,8 @@ class Attribute(BaseResource):
     @property
     def type(self):
         """:type: :class:`~tamr_unify_client.models.attribute.type.AttributeType`"""
-        alias = self.api_path + "/type"
         type_json = self._data.get("type")
-        return AttributeType.from_data(self.client, type_json, alias)
+        return AttributeType(self.client, type_json)
 
     @property
     def is_nullable(self):

--- a/tamr_unify_client/models/attribute/resource.py
+++ b/tamr_unify_client/models/attribute/resource.py
@@ -45,7 +45,7 @@ class Attribute(BaseResource):
     def type(self):
         """:type: :class:`~tamr_unify_client.models.attribute.type.AttributeType`"""
         type_json = self._data.get("type")
-        return AttributeType(self.client, type_json)
+        return AttributeType(type_json)
 
     @property
     def is_nullable(self):

--- a/tamr_unify_client/models/attribute/subattribute.py
+++ b/tamr_unify_client/models/attribute/subattribute.py
@@ -3,14 +3,11 @@ class SubAttribute:
     An attribute which is itself a property of another attribute.
     See https://docs.tamr.com/reference#attribute-types
 
-    :param client: Delegate underlying API calls to this client.
-    :type: :class:`~tamr_unify_client.Client`
     :param data: JSON data representing this attribute
     :type: :py:class:`dict`
     """
 
-    def __init__(self, client, data):
-        self.client = client
+    def __init__(self, data):
         self._data = data
 
     @property
@@ -30,7 +27,7 @@ class SubAttribute:
         from tamr_unify_client.models.attribute.type import AttributeType
 
         type_json = self._data.get("type")
-        return AttributeType(self.client, type_json)
+        return AttributeType(type_json)
 
     @property
     def is_nullable(self):

--- a/tamr_unify_client/models/attribute/subattribute.py
+++ b/tamr_unify_client/models/attribute/subattribute.py
@@ -1,0 +1,45 @@
+class SubAttribute:
+    """
+    An attribute which is itself a property of another attribute.
+    See https://docs.tamr.com/reference#attribute-types
+
+    :param client: Delegate underlying API calls to this client.
+    :type: :class:`~tamr_unify_client.Client`
+    :param data: JSON data representing this attribute
+    :type: :py:class:`dict`
+    """
+
+    def __init__(self, client, data):
+        self.client = client
+        self._data = data
+
+    @property
+    def name(self):
+        """:type: str"""
+        return self._data.get("name")
+
+    @property
+    def description(self):
+        """:type: str"""
+        return self._data.get("description")
+
+    @property
+    def type(self):
+        """:type: :class:`~tamr_unify_client.models.attribute.type.AttributeType`"""
+        # import locally to avoid circular dependency
+        from tamr_unify_client.models.attribute.type import AttributeType
+
+        type_json = self._data.get("type")
+        return AttributeType(self.client, type_json)
+
+    @property
+    def is_nullable(self):
+        """:type: bool"""
+        return self._data.get("isNullable")
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"name={self.name!r})"
+        )

--- a/tamr_unify_client/models/attribute/type.py
+++ b/tamr_unify_client/models/attribute/type.py
@@ -6,14 +6,11 @@ class AttributeType:
     The type of an :class:`~tamr_unify_client.models.attribute.resource.Attribute` or :class:`~tamr_unify_client.models.attribute.subattribute.SubAttribute`.
     See https://docs.tamr.com/reference#attribute-types
 
-    :param client: Delegate underlying API calls to this client.
-    :type: :class:`~tamr_unify_client.Client`
     :param data: JSON data representing this type
     :type: :py:class:`dict`
     """
 
-    def __init__(self, client, data):
-        self.client = client
+    def __init__(self, data):
         self._data = data
 
     @property
@@ -25,7 +22,7 @@ class AttributeType:
     def inner_type(self):
         """:type: :class:`~tamr_unify_client.models.attribute.type.AttributeType`"""
         if "innerType" in self._data:
-            return AttributeType(self.client, self._data.get("innerType"))
+            return AttributeType(self._data.get("innerType"))
         else:
             return None
 
@@ -33,7 +30,7 @@ class AttributeType:
     def attributes(self):
         """:type: list[:class:`~tamr_unify_client.models.attribute.subattribute.SubAttribute`]"""
         collection_json = self._data.get("attributes")
-        return [SubAttribute(self.client, attr) for attr in collection_json]
+        return [SubAttribute(attr) for attr in collection_json]
 
     def __repr__(self):
         return (

--- a/tamr_unify_client/models/attribute/type.py
+++ b/tamr_unify_client/models/attribute/type.py
@@ -1,14 +1,20 @@
-from tamr_unify_client.models.base_resource import BaseResource
+from tamr_unify_client.models.attribute.subattribute import SubAttribute
 
 
-class AttributeType(BaseResource):
-    @classmethod
-    def from_json(cls, client, data, api_path):
-        return super().from_data(client, data, api_path)
+class AttributeType:
+    """
+    The type of an :class:`~tamr_unify_client.models.attribute.resource.Attribute` or :class:`~tamr_unify_client.models.attribute.subattribute.SubAttribute`.
+    See https://docs.tamr.com/reference#attribute-types
 
-    @property
-    def relative_id(self):
-        return self.api_path
+    :param client: Delegate underlying API calls to this client.
+    :type: :class:`~tamr_unify_client.Client`
+    :param data: JSON data representing this type
+    :type: :py:class:`dict`
+    """
+
+    def __init__(self, client, data):
+        self.client = client
+        self._data = data
 
     @property
     def base_type(self):
@@ -19,27 +25,19 @@ class AttributeType(BaseResource):
     def inner_type(self):
         """:type: :class:`~tamr_unify_client.models.attribute.type.AttributeType`"""
         if "innerType" in self._data:
-            alias = self.api_path + "/type"
-            return AttributeType.from_data(
-                self.client, self._data.get("innerType"), alias
-            )
+            return AttributeType(self.client, self._data.get("innerType"))
         else:
             return None
 
     @property
     def attributes(self):
-        """:type: :class:`~tamr_unify_client.models.attribute.collection.AttributeCollection`"""
-        alias = self.api_path + "/attributes"
+        """:type: list[:class:`~tamr_unify_client.models.attribute.subattribute.SubAttribute`]"""
         collection_json = self._data.get("attributes")
-        # Import locally to avoid circular dependency
-        from tamr_unify_client.models.attribute.collection import AttributeCollection
-
-        return AttributeCollection.from_json(self.client, collection_json, alias)
+        return [SubAttribute(self.client, attr) for attr in collection_json]
 
     def __repr__(self):
         return (
             f"{self.__class__.__module__}."
             f"{self.__class__.__qualname__}("
-            f"relative_id={self.relative_id!r}, "
             f"base_type={self.base_type!r})"
         )

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -52,8 +52,7 @@ class Dataset(BaseResource):
         :rtype: :class:`~tamr_unify_client.models.attribute.collection.AttributeCollection`
         """
         alias = self.api_path + "/attributes"
-        resource_json = self.client.get(alias).successful().json()
-        return AttributeCollection.from_json(self.client, resource_json, alias)
+        return AttributeCollection(self.client, alias)
 
     def update_records(self, records):
         """Send a batch of record creations/updates/deletions to this dataset.

--- a/tamr_unify_client/models/project/resource.py
+++ b/tamr_unify_client/models/project/resource.py
@@ -47,8 +47,7 @@ class Project(BaseResource):
         from tamr_unify_client.models.attribute.collection import AttributeCollection
 
         alias = self.api_path + "/attributes"
-        resource_json = self.client.get(alias).successful().json()
-        return AttributeCollection.from_json(self.client, resource_json, alias)
+        return AttributeCollection(self.client, alias)
 
     def unified_dataset(self):
         """Unified dataset for this project.

--- a/tests/unit/test_attribute.py
+++ b/tests/unit/test_attribute.py
@@ -50,9 +50,8 @@ class TestAttribute(TestCase):
         self.assertIsNone(geom.type.inner_type)
         self.assertEqual(3, len(list(geom.type.attributes)))
 
-        point = list(geom.type.attributes)[0]
+        point = geom.type.attributes[0]
         self.assertEqual("point", point.name)
-        self.assertEqual(alias + "/type/attributes/point", point.relative_id)
         self.assertTrue(point.is_nullable)
         self.assertEqual("ARRAY", point.type.base_type)
         self.assertEqual("DOUBLE", point.type.inner_type.base_type)


### PR DESCRIPTION
Fix #172 
Fix #175 

Doing a few things:
- getting rid of json attached to `AttributeCollection`s
- making `AttributeType` no longer inherit from `BaseResource` as it doesn't have an API endpoint
- creating a new `SubAttribute` class (not a `BaseResource`) that is a property of other `Attribute`s