### PR TITLE
Stream dataset records as updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - [#175](https://github.com/Datatamer/unify-client-python/issues/175) `AttributeCollection` no longer has a `from_json` method or a `data` parameter in its constructor
   - `AttributeType` no longer inherits from `BaseResource` (no API path), removing its `from_json` method and `relative_id` property
   - The type of `AttributeType`'s `attributes` property is now a `list` of `SubAttribute`s, which are identical to `Attribute`s except they lack an API path
+  - The `Dataset` function `update_records` has been renamed `_update_records` as the convenience functions `upsert_records` and `delete_records` now exist.
 
   **NEW FEATURES**
   - [#174](https://github.com/Datatamer/unify-client-python/issues/174) Get and create taxonomy categories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - [#202](https://github.com/Datatamer/unify-client-python/issues/202) Support for refreshing published cluster stats
   - [#194](https://github.com/Datatamer/unify-client-python/issues/194) Allowing additional JSON parameters to be used for update of records
   - [#205](https://github.com/Datatamer/unify-client-python/issues/205) Update a dataset's records with records rather than record updates
+  - Delete records from a dataset by providing records rather than record updates
 
   **BUG FIXES**
   - [#212](https://github.com/Datatamer/unify-client-python/issues/212) Sped up slow running tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - [#181](https://github.com/Datatamer/unify-client-python/issues/181) Support for seeing a dataset's usage
   - [#202](https://github.com/Datatamer/unify-client-python/issues/202) Support for refreshing published cluster stats
   - [#194](https://github.com/Datatamer/unify-client-python/issues/194) Allowing additional JSON parameters to be used for update of records
+  - [#205](https://github.com/Datatamer/unify-client-python/issues/205) Update a dataset's records with records rather than record updates
 
   **BUG FIXES**
   - [#212](https://github.com/Datatamer/unify-client-python/issues/212) Sped up slow running tests

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -80,6 +80,24 @@ class Dataset(BaseResource):
             .json()
         )
 
+    def upsert_records(self, records, primary_key_name, **json_args):
+        """Converts the records into update commands and calls :func:`~tamr_unify_client.models.dataset.resource.Dataset.update_records`
+
+        :param records: The records to update, as dictionaries.
+        :type records: iterable[dict]
+        :param primary_key_name: The name of the primary key for these records, which must be a key in each record dictionary.
+        :type primary_key_name: str
+        :param `**json_args`: Arguments to pass to the JSON `dumps` function, as documented `here <https://simplejson.readthedocs.io/en/latest/#simplejson.dumps>`_.
+            Some of these, such as `indent`, may not work with Unify.
+        :return: JSON response body from the server.
+        :rtype: dict
+        """
+        updates = (
+            {"action": "CREATE", "recordId": record[primary_key_name], "record": record}
+            for record in records
+        )
+        return self.update_records(updates, **json_args)
+
     def refresh(self, **options):
         """Brings dataset up-to-date if needed, taking whatever actions are required.
         :param ``**options``: Options passed to underlying :class:`~tamr_unify_client.models.operation.Operation` .

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -98,6 +98,22 @@ class Dataset(BaseResource):
         )
         return self.update_records(updates, **json_args)
 
+    def delete_records(self, records, primary_key_name):
+        """Converts the records into delete commands and calls :func:`~tamr_unify_client.models.dataset.resource.Dataset.update_records`
+
+        :param records: The records to delete, as dictionaries.
+        :type records: iterable[dict]
+        :param primary_key_name: The name of the primary key for these records, which must be a key in each record dictionary.
+        :type primary_key_name: str
+        :return: JSON response body from the server.
+        :rtype: dict
+        """
+        updates = (
+            {"action": "DELETE", "recordId": record[primary_key_name]}
+            for record in records
+        )
+        return self.update_records(updates)
+
     def refresh(self, **options):
         """Brings dataset up-to-date if needed, taking whatever actions are required.
         :param ``**options``: Options passed to underlying :class:`~tamr_unify_client.models.operation.Operation` .

--- a/tamr_unify_client/models/dataset/resource.py
+++ b/tamr_unify_client/models/dataset/resource.py
@@ -109,10 +109,18 @@ class Dataset(BaseResource):
         :return: JSON response body from the server.
         :rtype: dict
         """
-        updates = (
-            {"action": "DELETE", "recordId": record[primary_key_name]}
-            for record in records
-        )
+        ids = (record[primary_key_name] for record in records)
+        return self.delete_records_by_id(ids)
+
+    def delete_records_by_id(self, record_ids):
+        """Deletes the specified records.
+
+        :param record_ids: The IDs of the records to delete.
+        :type record_ids: iterable
+        :return: JSON response body from the server.
+        :rtype: dict
+        """
+        updates = ({"action": "DELETE", "recordId": rid} for rid in record_ids)
         return self._update_records(updates)
 
     def refresh(self, **options):

--- a/tests/unit/test_dataset_records.py
+++ b/tests/unit/test_dataset_records.py
@@ -79,11 +79,31 @@ class TestDatasetRecords(TestCase):
         self.assertEqual(response, self._response_json)
         self.assertEqual(snoop["payload"], TestDatasetRecords.stringify(updates, True))
 
+    @responses.activate
+    def test_upsert(self):
+        def create_callback(request, snoop):
+            snoop["payload"] = list(request.body)
+            return 200, {}, simplejson.dumps(self._response_json)
+
+        responses.add(responses.GET, self._dataset_url, json={})
+        dataset = self.unify.datasets.by_resource_id(self._dataset_id)
+
+        records_url = f"{self._dataset_url}:updateRecords"
+        updates = TestDatasetRecords.records_to_updates(self._records_json)
+        snoop = {}
+        responses.add_callback(
+            responses.POST, records_url, partial(create_callback, snoop=snoop)
+        )
+
+        response = dataset.upsert_records(self._records_json, "attribute1")
+        self.assertEqual(response, self._response_json)
+        self.assertEqual(snoop["payload"], TestDatasetRecords.stringify(updates, False))
+
     @staticmethod
     def records_to_updates(records):
         return [
-            {"action": "CREATE", "recordId": str(i), "record": records[i]}
-            for i in range(len(records))
+            {"action": "CREATE", "recordId": i, "record": record}
+            for i, record in enumerate(records, start=1)
         ]
 
     @staticmethod

--- a/tests/unit/test_dataset_records.py
+++ b/tests/unit/test_dataset_records.py
@@ -44,7 +44,7 @@ class TestDatasetRecords(TestCase):
             responses.POST, records_url, partial(create_callback, snoop=snoop)
         )
 
-        response = dataset.update_records(updates)
+        response = dataset._update_records(updates)
         self.assertEqual(response, self._response_json)
         self.assertEqual(snoop["payload"], TestDatasetRecords.stringify(updates, False))
 
@@ -72,10 +72,10 @@ class TestDatasetRecords(TestCase):
             partial(create_callback, snoop=snoop, status=200),
         )
 
-        self.assertRaises(HTTPError, lambda: dataset.update_records(updates))
+        self.assertRaises(HTTPError, lambda: dataset._update_records(updates))
         self.assertEqual(snoop["payload"], TestDatasetRecords.stringify(updates, False))
 
-        response = dataset.update_records(updates, ignore_nan=True)
+        response = dataset._update_records(updates, ignore_nan=True)
         self.assertEqual(response, self._response_json)
         self.assertEqual(snoop["payload"], TestDatasetRecords.stringify(updates, True))
 


### PR DESCRIPTION
Fix #205 

Given datasets `d1` and `d2`, the following code works:
`d2.upsert_records(d1.records(), d1_primary_key_name)`

