### PR TITLE
Delete all records from a dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - [#205](https://github.com/Datatamer/unify-client-python/issues/205) Update a dataset's records with records rather than record updates
   - Delete records from a dataset by providing records rather than record updates
   - [#183](https://github.com/Datatamer/unify-client-python/issues/183) Retrieve versions of published clusters
+  - [#220](https://github.com/Datatamer/unify-client-python/issues/220) Delete all records from a dataset
 
   **BUG FIXES**
   - [#212](https://github.com/Datatamer/unify-client-python/issues/212) Sped up slow running tests

--- a/tamr_unify_client/dataset/resource.py
+++ b/tamr_unify_client/dataset/resource.py
@@ -123,6 +123,16 @@ class Dataset(BaseResource):
         updates = ({"action": "DELETE", "recordId": rid} for rid in record_ids)
         return self._update_records(updates)
 
+    def delete_all_records(self):
+        """Removes all records from the dataset.
+
+        :return: HTTP response from the server
+        :rtype: :class:`requests.Response`
+        """
+        path = self.api_path + "/records"
+        response = self.client.delete(path).successful()
+        return response
+
     def refresh(self, **options):
         """Brings dataset up-to-date if needed, taking whatever actions are required.
 

--- a/tests/unit/test_dataset_records.py
+++ b/tests/unit/test_dataset_records.py
@@ -140,6 +140,15 @@ class TestDatasetRecords(TestCase):
         self.assertEqual(response, self._response_json)
         self.assertEqual(snoop["payload"], TestDatasetRecords.stringify(deletes, False))
 
+    @responses.activate
+    def test_delete_all(self):
+        responses.add(responses.GET, self._dataset_url, json={})
+        dataset = self.unify.datasets.by_resource_id(self._dataset_id)
+
+        responses.add(responses.DELETE, self._dataset_url + "/records", status=204)
+        response = dataset.delete_all_records()
+        self.assertEqual(response.status_code, 204)
+
     @staticmethod
     def records_to_deletes(records):
         return [


### PR DESCRIPTION
# ↪️ Pull Request

Fix #220 

First delete endpoint, so not sure if it should wait for v0.9.0.

I don't know how to unit test it more. It does work on a real unify instance.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
