### PR TITLE
MISSING INDENT

### DIFF
--- a/tamr_unify_client/project/attribute_mapping/collection.py
+++ b/tamr_unify_client/project/attribute_mapping/collection.py
@@ -33,7 +33,7 @@ class AttributeMappingCollection:
             split_id = mapping.resource_id
             if resource_id == split_id:
                 return mapping
-            raise LookupError("cannot locate mapping from resource ID")
+        raise LookupError("cannot locate mapping from resource ID")
 
     def by_relative_id(self, relative_id):
         """Retrieve an item in this collection by relative ID.


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ merge of support for attribute mappings had a line with a missing indent, causing "by_resource_id" to only be able to return an AttributeMapping if it was the first one

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## ✔️ PR Todo

- [ ] Added/updated testing for this change
- [ ] Included links to related issues/PRs
- [ ] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
