### PR TITLE
Getting attributes from a collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.9.0-dev
+  **BUG FIXES**
+   - [#235](https://github.com/Datatamer/unify-client-python/issues/235) Making `AttributeCollection` retrieve attributes directly instead of by streaming
 
 ## 0.8.0
   **BREAKING CHANGES**

--- a/tamr_unify_client/attribute/collection.py
+++ b/tamr_unify_client/attribute/collection.py
@@ -23,7 +23,7 @@ class AttributeCollection(BaseCollection):
         :returns: The specified attribute.
         :rtype: :class:`~tamr_unify_client.attribute.resource.Attribute`
         """
-        return self.by_name(resource_id)
+        return super().by_resource_id(self.api_path, resource_id)
 
     def by_relative_id(self, relative_id):
         """Retrieve an attribute by relative ID.
@@ -33,8 +33,7 @@ class AttributeCollection(BaseCollection):
         :returns: The specified attribute.
         :rtype: :class:`~tamr_unify_client.attribute.resource.Attribute`
         """
-        resource_id = relative_id.split("/")[-1]
-        return self.by_resource_id(resource_id)
+        return super().by_relative_id(Attribute, relative_id)
 
     def by_external_id(self, external_id):
         """Retrieve an attribute by external ID.
@@ -76,12 +75,8 @@ class AttributeCollection(BaseCollection):
         :type attribute_name: str
         :return: Attribute with matching name in this collection.
         :rtype: :class:`~tamr_unify_client.attribute.resource.Attribute`
-        :raises KeyError: If no attribute with specified name was found.
         """
-        for attribute in self:
-            if attribute.name == attribute_name:
-                return attribute
-        raise KeyError(f"No attribute found with name: {attribute_name}")
+        return super().by_resource_id(self.api_path, attribute_name)
 
     def create(self, creation_spec):
         """

--- a/tests/unit/test_dataset_attributes.py
+++ b/tests/unit/test_dataset_attributes.py
@@ -26,7 +26,9 @@ def test_dataset_attributes():
         status=204,
     )
     responses.add(
-        responses.GET, dataset_url + "/attributes", json=[attribute_creation_spec]
+        responses.GET,
+        dataset_url + "/attributes/myAttribute",
+        json=attribute_creation_spec,
     )
 
     dataset = unify.datasets.by_resource_id("1")

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -56,6 +56,12 @@ class TestProject(TestCase):
         project = self.unify.projects.by_external_id(self.project_external_id)
         attributes = list(project.attributes)
         self.assertEqual(len(self.project_attributes_json), len(attributes))
+
+        responses.add(
+            responses.GET,
+            self.project_attributes_url + "/id",
+            json=self.project_attributes_json[0],
+        )
         id_attribute = project.attributes.by_name("id")
         self.assertEqual(self.project_attributes_json[0]["name"], id_attribute.name)
 


### PR DESCRIPTION
# ↪️ Pull Request

Fix #235 

Currently, to retrieve a specific attribute, an `AttributeCollection` streams the attributes and locates the one with the right name. This change is to directly use the API endpoints that get specific records instead (for attributes, name is equivalent to resource ID).

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`