### PR TITLE
Attribute configuration

### DIFF
--- a/docs/beta/attribute.md
+++ b/docs/beta/attribute.md
@@ -3,3 +3,4 @@
   * [Attribute](/beta/attribute/attribute)
   * [Attribute Type](/beta/attribute/type)
   * [SubAttribute](/beta/attribute/sub)
+  * [Attribute Configuration](/beta/attribute/configuration)

--- a/docs/beta/attribute/configuration.rst
+++ b/docs/beta/attribute/configuration.rst
@@ -1,0 +1,25 @@
+Attribute
+=========
+
+.. autoclass:: tamr_client.AttributeConfiguration
+
+.. autofunction:: tamr_client.attribute.configuration.by_resource_id
+.. autofunction:: tamr_client.attribute.configuration.get_all
+.. autofunction:: tamr_client.attribute.configuration.create
+.. autofunction:: tamr_client.attribute.configuration.update
+.. autofunction:: tamr_client.attribute.configuration.delete
+
+Exceptions
+----------
+
+.. autoclass:: tamr_client.attribute.configuration.NotFound
+  :no-inherited-members:
+
+.. autoclass:: tamr_client.attribute.configuration.Ambiguous
+  :no-inherited-members:
+
+.. autoclass:: tamr_client.attribute.configuration.AlreadyExists
+  :no-inherited-members:
+
+.. autoclass:: tamr_client.attribute.configuration.Invalid
+  :no-inherited-members:

--- a/tamr_client/__init__.py
+++ b/tamr_client/__init__.py
@@ -19,6 +19,7 @@ _beta.check()
 from tamr_client._types import (
     AnyDataset,
     Attribute,
+    AttributeConfiguration,
     AttributeMapping,
     AttributeType,
     Backup,

--- a/tamr_client/_types/__init__.py
+++ b/tamr_client/_types/__init__.py
@@ -22,12 +22,16 @@ from tamr_client._types.instance import Instance
 from tamr_client._types.json import JsonDict
 from tamr_client._types.operation import Operation
 from tamr_client._types.project import (
+    AttributeConfiguration,
     AttributeMapping,
+    AttributeRole,
     CategorizationProject,
     GoldenRecordsProject,
     MasteringProject,
     Project,
     SchemaMappingProject,
+    SimilarityFunction,
+    Tokenizer,
     UnknownProject,
 )
 from tamr_client._types.restore import Restore

--- a/tamr_client/_types/project.py
+++ b/tamr_client/_types/project.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Optional, Union
+from enum import Enum
+from typing import List, Optional, Union
 
 from tamr_client._types.attribute import Attribute
 from tamr_client._types.url import URL
@@ -114,3 +115,66 @@ class AttributeMapping:
     url: URL
     input_attribute: Attribute
     unified_attribute: Attribute
+
+
+SimilarityFunction = Enum(
+    "SimilarityFunction",
+    [
+        "COSINE",
+        "JACCARD",
+        "ABSOLUTE_DIFF",
+        "RELATIVE_DIFF",
+        "GEOSPATIAL_HAUSDORFF",
+        "GEOSPATIAL_DIRECTIONAL_HAUSDORFF",
+        "GEOSPATIAL_MIN_DISTANCE",
+        "GEOSPATIAL_RELATIVE_HAUSDORFF",
+        "GEOSPATIAL_RELATIVE_AREA_OVERLAP",
+    ],
+)
+
+Tokenizer = Enum(
+    "Tokenizer",
+    {
+        "DEFAULT": "DEFAULT",
+        "STEMMING_EN": "STEMMING_EN",
+        "REGEX": "REGEX",
+        "BIGRAM": "BIGRAM",
+        "TRIGRAM": "TRIGRAM",
+        "BIWORD": "BIWORD",
+        "NONE": "",
+    },
+)
+
+AttributeRole = Enum(
+    "AttributeRole",
+    {
+        "CLUSTER_NAME_ATTRIBUTE": "CLUSTER_NAME_ATTRIBUTE",
+        "SUM_ATTRIBUTE": "SUM_ATTRIBUTE",
+        "NONE": "",
+    },
+)
+
+
+@dataclass(frozen=True)
+class AttributeConfiguration:
+    """A Tamr Attribute Configuration.
+
+    See https://docs.tamr.com/previous/reference/attribute-configuration
+
+    Args:
+        url
+        attribute
+        attribute_role
+        similarity_function
+        enabled_for_ml
+        tokenizer
+        numeric_field_resolution
+    """
+
+    url: URL
+    attribute: Attribute
+    attribute_role: AttributeRole
+    similarity_function: SimilarityFunction
+    enabled_for_ml: bool
+    tokenizer: Tokenizer
+    numeric_field_resolution: List[int]

--- a/tamr_client/attribute/__init__.py
+++ b/tamr_client/attribute/__init__.py
@@ -1,6 +1,8 @@
+from tamr_client.attribute import configuration
 from tamr_client.attribute import sub
 from tamr_client.attribute import type
 from tamr_client.attribute._attribute import (
+    _by_url,
     _from_json,
     AlreadyExists,
     by_resource_id,

--- a/tamr_client/attribute/configuration.py
+++ b/tamr_client/attribute/configuration.py
@@ -1,0 +1,333 @@
+"""
+See https://docs.tamr.com/previous/reference/attribute-configuration
+"""
+from copy import deepcopy
+from dataclasses import replace
+from typing import List, Optional, Tuple
+
+from tamr_client import attribute, response
+from tamr_client._types import (
+    Attribute,
+    AttributeConfiguration,
+    AttributeRole,
+    JsonDict,
+    Project,
+    Session,
+    SimilarityFunction,
+    Tokenizer,
+    URL,
+)
+from tamr_client.exception import TamrClientException
+
+
+class AlreadyExists(TamrClientException):
+    """Raised when an attribute configuration with these specifications already exists."""
+
+    pass
+
+
+class NotFound(TamrClientException):
+    """Raised when referencing an attribute configuration that does not exist on the server."""
+
+    pass
+
+
+class Ambiguous(TamrClientException):
+    """Raised when an attribute configuration specification is incomplete, ambiguous, or contradictory."""
+
+    pass
+
+
+class Invalid(TamrClientException):
+    """Raised when an improper configuration is specified."""
+
+    pass
+
+
+def _from_json(
+    url: URL, unified_attribute: Attribute, data: JsonDict
+) -> AttributeConfiguration:
+    """Make attribute configuration from JSON data (deserialize)
+
+    Args:
+        url: Attribute configuration URL
+        data: Attribute configuration JSON data from Tamr server
+    """
+    cp = deepcopy(data)
+    return AttributeConfiguration(
+        url,
+        attribute=unified_attribute,
+        attribute_role=AttributeRole[cp["attributeRole"]]
+        if len(cp["attributeRole"]) > 0
+        else AttributeRole.NONE,
+        similarity_function=SimilarityFunction[cp["similarityFunction"]],
+        enabled_for_ml=cp["enabledForMl"],
+        tokenizer=Tokenizer[cp["tokenizer"]]
+        if len(cp["tokenizer"]) > 0
+        else Tokenizer.NONE,
+        numeric_field_resolution=cp["numericFieldResolution"],
+    )
+
+
+def _by_url(session: Session, url: URL) -> AttributeConfiguration:
+    """Get attribute configuration by URL
+
+    Fetches attribute configuration from Tamr server
+
+    Args:
+        url: Attribute configuration URL
+
+    Raises:
+        attribute.configuration.NotFound: If no attribute configuration could be found at the specified URL.
+            Corresponds to a 404 HTTP error.
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    r = session.get(str(url))
+    if r.status_code == 404:
+        raise NotFound(str(url))
+    data = response.successful(r).json()
+
+    # Construct attribute configuration
+    return _with_attribute(session, url, data)
+
+
+def _with_attribute(
+    session: Session, url: URL, data: JsonDict
+) -> AttributeConfiguration:
+    """Get attribute configuration with relevant attribute constructed
+
+    Fetches attribute configuration from Tamr server
+
+    Args:
+        url: Attribute configuration URL
+        data: Attribute configuration JSON data from Tamr server
+
+    Raises:
+        attribute.NotFound: If no attribute could be found at the specified URL.
+            Corresponds to a 404 HTTP error.
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    cp = deepcopy(data)
+    # Get unified attribute
+    attribute_id = "/".join(cp["relativeAttributeId"].split("/")[2:])
+    attribute_path = "/".join(cp["relativeId"].split("/")[:2]) + "/" + attribute_id
+    attribute_url = replace(url, path=attribute_path)
+    unified_attribute = attribute._by_url(session, attribute_url)
+
+    # Construct attribute configuration
+    return _from_json(url, unified_attribute, cp)
+
+
+def by_resource_id(
+    session: Session, project: Project, id: str
+) -> AttributeConfiguration:
+    """Get attribute configuration by resource ID
+
+    Fetches attribute configuration from Tamr server
+
+    Args:
+        project: Project containing this attribute configuration
+        id: Attribute configuration ID
+
+    Raises:
+        attribute.configuration.NotFound: If no attribute configuration could be found at the specified URL.
+            Corresponds to a 404 HTTP error.
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    url = replace(project.url, path=project.url.path + f"/attributeConfigurations/{id}")
+    return _by_url(session, url)
+
+
+def create(
+    session: Session,
+    project: Project,
+    *,
+    unified_attribute: Attribute,
+    attribute_role: AttributeRole = AttributeRole.NONE,
+    similarity_function: SimilarityFunction = SimilarityFunction.COSINE,
+    enabled_for_ml: bool = True,
+    tokenizer: Optional[Tokenizer] = None,
+    numeric_field_resolution: Optional[List[int]] = None,
+) -> AttributeConfiguration:
+    """Create an attribute in Tamr for the given project.
+
+    Args:
+        project: Tamr project
+        unified_attribute: The attribute of the unified dataset to configure
+        attribute_role: The role of the attribute as spend or cluster name
+        similarity_function: The similarity function to use for this attribute
+        enabled_for_ml: Whether to include this attribute in the machine-learning model
+        tokenizer: The tokenizer to use for this attribute for text similarity functions
+        numeric_field_resolution: Resolution to use for numeric similarity functions
+
+    Returns:
+        Attribute configuration created in Tamr
+
+    Raises:
+        attribute.configuration.AlreadyExists: If an attribute configuration already exists.
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    if numeric_field_resolution is None:
+        numeric_field_resolution = []
+    if similarity_function in [SimilarityFunction.COSINE, SimilarityFunction.JACCARD]:
+        # Use default tokenizer if none passed
+        if tokenizer is None:
+            tokenizer = Tokenizer.DEFAULT
+        elif tokenizer not in Tokenizer or tokenizer == Tokenizer.NONE:
+            raise Invalid("A tokenizer must be used with text similarity functions.")
+        if len(numeric_field_resolution) > 0:
+            raise Invalid(
+                "Numeric field resolution cannot be used for text similarity functions."
+            )
+    else:
+        if tokenizer is None:
+            tokenizer = Tokenizer.NONE
+        if tokenizer != Tokenizer.NONE:
+            raise Invalid(
+                "A tokenizer cannot be used with non-text similarity functions."
+            )
+
+    data = {
+        "attributeName": unified_attribute.name,
+        "attributeRole": attribute_role.value,
+        "similarityFunction": similarity_function.name,
+        "enabledForMl": enabled_for_ml,
+        "tokenizer": tokenizer.value,
+        "numericFieldResolution": numeric_field_resolution,
+    }
+
+    r = session.post(url=str(project.url) + "/attributeConfigurations", json=data)
+
+    # Note: This call will create a unified attribute (name only) if it does not already exist
+    if r.status_code == 409:
+        raise AlreadyExists(
+            "An attribute configuration for this attribute already exists."
+        )
+    if r.status_code == 400:
+        raise Ambiguous(r.json()["message"])
+
+    data = response.successful(r).json()
+    url = replace(project.url, path=str(data["relativeId"]))
+    return _from_json(url, unified_attribute, data)
+
+
+def update(
+    session: Session,
+    attribute_configuration: AttributeConfiguration,
+    *,
+    attribute_role: Optional[AttributeRole] = None,
+    similarity_function: Optional[SimilarityFunction] = None,
+    enabled_for_ml: Optional[bool] = None,
+    tokenizer: Optional[Tokenizer] = None,
+    numeric_field_resolution: Optional[List[int]] = None,
+) -> AttributeConfiguration:
+    """Update an existing attribute configuration in Tamr.
+
+    Args:
+        attribute_configuration: Existing attribute configuration to update
+        attribute_role: The role of the attribute as spend or cluster name
+        similarity_function: The similarity function to use
+        enabled_for_ml: Whether to include this attribute in the machine-learning model
+        tokenizer: The tokenizer to use for text similarity functions
+        numeric_field_resolution: Resolution to use for numeric similarity functions
+
+    Returns:
+        Attribute configuration updated in Tamr
+
+    Raises:
+        attribute.configuration.NotFound: If no attribute configuration could be found at the specified URL.
+            Corresponds to a 404 HTTP error.
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    # Use current values as defaults for non-nullable values
+    if attribute_role is None:
+        attribute_role = attribute_configuration.attribute_role
+    if similarity_function is None:
+        similarity_function = attribute_configuration.similarity_function
+    if enabled_for_ml is None:
+        enabled_for_ml = attribute_configuration.enabled_for_ml
+
+    # Null numeric field resolution if similarity function is text
+    # Null default tokenizer if similarity function is non-text
+    if similarity_function in [SimilarityFunction.COSINE, SimilarityFunction.JACCARD]:
+        if numeric_field_resolution is None:
+            numeric_field_resolution = []
+        if tokenizer is None:
+            tokenizer = attribute_configuration.tokenizer
+        if tokenizer not in Tokenizer or tokenizer == Tokenizer.NONE:
+            raise Invalid("A tokenizer must be used with text similarity functions.")
+        if len(numeric_field_resolution) > 0:
+            raise Invalid(
+                "Numeric field resolution cannot be used for text similarity functions."
+            )
+    else:
+        if numeric_field_resolution is None:
+            numeric_field_resolution = attribute_configuration.numeric_field_resolution
+        if tokenizer is None:
+            tokenizer = Tokenizer.NONE
+        if tokenizer != Tokenizer.NONE:
+            raise Invalid(
+                "A tokenizer cannot be used with non-text similarity functions."
+            )
+
+    data = {
+        "attributeName": attribute_configuration.attribute.name,
+        "attributeRole": attribute_role.value,
+        "similarityFunction": similarity_function.name,
+        "enabledForMl": enabled_for_ml,
+        "tokenizer": tokenizer.value,
+        "numericFieldResolution": numeric_field_resolution,
+    }
+
+    r = session.put(url=str(attribute_configuration.url), json=data)
+
+    if r.status_code == 404:
+        raise NotFound(str(attribute_configuration.url))
+    if r.status_code == 400:
+        raise Ambiguous(r.json()["message"])
+
+    return _from_json(
+        attribute_configuration.url,
+        unified_attribute=attribute_configuration.attribute,
+        data=data,
+    )
+
+
+def get_all(session: Session, project: Project) -> Tuple[AttributeConfiguration, ...]:
+    """Get all attribute configurations of a Tamr project
+
+    Args:
+        project: Tamr project
+
+    Returns:
+        The attribute configurations of the project
+
+    Raises:
+        requests.HTTPError: If an HTTP error is encountered.
+    """
+    url = str(project.url) + "/attributeConfigurations"
+    r = session.get(url=url)
+    data = response.successful(r).json()
+    attr_configs = [
+        _with_attribute(session, replace(project.url, path=d["relativeId"]), d)
+        for d in data
+    ]
+
+    return tuple(attr_configs)
+
+
+def delete(session: Session, attribute_configuration: AttributeConfiguration):
+    """Delete an existing attribute configuration
+
+    Args:
+        attribute_configuration: Existing attribute configuration to delete
+
+    Raises:
+        attribute.configuration.NotFound: If no attribute mapping could be found at the specified URL.
+            Corresponds to a 404 HTTP error.
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    r = session.delete(str(attribute_configuration.url))
+    if r.status_code == 404:
+        raise NotFound(str(attribute_configuration.url))
+    response.successful(r)

--- a/tamr_client/schema_mapping/attribute_mapping.py
+++ b/tamr_client/schema_mapping/attribute_mapping.py
@@ -2,7 +2,7 @@
 See https://docs.tamr.com/new/reference/retrieve-projects-mappings
 """
 from copy import deepcopy
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 from tamr_client import attribute, dataset, response
 from tamr_client import project as tc_project
@@ -88,7 +88,7 @@ def create(
     )
 
 
-def get_all(session: Session, tamr_project: Project) -> List[AttributeMapping]:
+def get_all(session: Session, tamr_project: Project) -> Tuple[AttributeMapping, ...]:
     """Get all attribute mappings of a Tamr project
 
     Args:
@@ -114,7 +114,7 @@ def get_all(session: Session, tamr_project: Project) -> List[AttributeMapping]:
             attribute_memo=attribute_memo,
         )
         mapping_list.append(mapping)
-    return mapping_list
+    return tuple(mapping_list)
 
 
 def _get(

--- a/tests/tamr_client/attribute/test_attribute_configuration.py
+++ b/tests/tamr_client/attribute/test_attribute_configuration.py
@@ -1,0 +1,188 @@
+from typing import List, Tuple
+
+import pytest
+
+import tamr_client as tc
+from tests.tamr_client import fake
+
+
+_attribute_configuration_json = {
+    "id": "unify://unified-data/v1/projects/1/attributeConfigurations/1600",
+    "relativeId": "projects/1/attributeConfigurations/1600",
+    "relativeAttributeId": "datasets/1/attributes/street_address",
+    "attributeRole": "",
+    "similarityFunction": "COSINE",
+    "enabledForMl": True,
+    "tokenizer": "DEFAULT",
+    "numericFieldResolution": [],
+    "attributeName": "StreetAddress",
+}
+
+AttributeRole = tc.attribute.configuration.AttributeRole
+SimilarityFunction = tc.attribute.configuration.SimilarityFunction
+Tokenizer = tc.attribute.configuration.Tokenizer
+
+
+@fake.json
+def test_by_resource_id():
+    s = fake.session()
+    project = fake.mastering_project()
+
+    attribute_conf = tc.attribute.configuration.by_resource_id(s, project, "1600")
+
+    assert isinstance(attribute_conf, tc.AttributeConfiguration)
+    assert attribute_conf.attribute_role is AttributeRole.NONE
+    assert attribute_conf.similarity_function == SimilarityFunction.COSINE
+    assert attribute_conf.enabled_for_ml
+    assert attribute_conf.tokenizer == Tokenizer.DEFAULT
+    assert attribute_conf.numeric_field_resolution == []
+    assert isinstance(attribute_conf.attribute, tc.Attribute)
+    assert attribute_conf.attribute.name == "StreetAddress"
+
+
+@fake.json
+def test_create():
+    s = fake.session()
+    project = fake.mastering_project()
+    attribute = fake.project_attribute()
+
+    attribute_conf = tc.attribute.configuration.create(
+        s,
+        project,
+        unified_attribute=attribute,
+        attribute_role=tc.attribute.configuration.AttributeRole.CLUSTER_NAME_ATTRIBUTE,
+        similarity_function=tc.attribute.configuration.SimilarityFunction.COSINE,
+        enabled_for_ml=True,
+        tokenizer=tc.attribute.configuration.Tokenizer.DEFAULT,
+        numeric_field_resolution=None,
+    )
+
+    assert isinstance(attribute_conf, tc.AttributeConfiguration)
+    assert attribute_conf.attribute_role == AttributeRole.CLUSTER_NAME_ATTRIBUTE
+    assert attribute_conf.similarity_function == SimilarityFunction.COSINE
+    assert attribute_conf.enabled_for_ml
+    assert attribute_conf.tokenizer == Tokenizer.DEFAULT
+    assert attribute_conf.numeric_field_resolution == []
+    assert attribute_conf.attribute == attribute
+
+
+@fake.json
+def test_create_numeric():
+    s = fake.session()
+    project = fake.mastering_project()
+    attribute = fake.project_attribute()
+
+    attribute_conf = tc.attribute.configuration.create(
+        s,
+        project,
+        unified_attribute=attribute,
+        similarity_function=tc.attribute.configuration.SimilarityFunction.ABSOLUTE_DIFF,
+        enabled_for_ml=True,
+    )
+
+    assert isinstance(attribute_conf, tc.AttributeConfiguration)
+    assert attribute_conf.attribute_role == AttributeRole.NONE
+    assert attribute_conf.similarity_function == SimilarityFunction.ABSOLUTE_DIFF
+    assert attribute_conf.enabled_for_ml
+    assert attribute_conf.tokenizer == Tokenizer.NONE
+    assert attribute_conf.numeric_field_resolution == []
+    assert attribute_conf.attribute == attribute
+
+
+def test_create_bad_parameters():
+    param_sets: List[Tuple[SimilarityFunction, Tokenizer, List[int]]] = [
+        (SimilarityFunction.COSINE, Tokenizer.DEFAULT, [1]),
+        (SimilarityFunction.COSINE, Tokenizer.NONE, []),
+        (SimilarityFunction.ABSOLUTE_DIFF, Tokenizer.DEFAULT, []),
+    ]
+    s = fake.session()
+    project = fake.mastering_project()
+    attribute = fake.project_attribute()
+    for param in param_sets:
+        with pytest.raises(tc.attribute.configuration.Invalid):
+            tc.attribute.configuration.create(
+                s,
+                project,
+                unified_attribute=attribute,
+                similarity_function=param[0],
+                tokenizer=param[1],
+                numeric_field_resolution=param[2],
+            )
+
+
+@fake.json
+def test_get_all():
+    s = fake.session()
+    project = fake.mastering_project()
+
+    attribute_confs = tc.attribute.configuration.get_all(s, project)
+    assert len(attribute_confs) == 2
+
+    attribute_conf = attribute_confs[1]
+    assert isinstance(attribute_conf, tc.AttributeConfiguration)
+    assert attribute_conf.attribute_role == AttributeRole.NONE
+    assert attribute_conf.similarity_function == SimilarityFunction.JACCARD
+    assert attribute_conf.enabled_for_ml
+    assert attribute_conf.tokenizer == Tokenizer.BIWORD
+    assert attribute_conf.numeric_field_resolution == []
+    assert isinstance(attribute_conf.attribute, tc.Attribute)
+    assert attribute_conf.attribute.name == "StreetAddress2"
+
+
+@fake.json
+def test_update():
+    s = fake.session()
+    attribute_conf = fake.attribute_configuration()
+    updated_attr_conf = tc.attribute.configuration.update(
+        s,
+        attribute_conf,
+        attribute_role=tc.attribute.configuration.AttributeRole.SUM_ATTRIBUTE,
+        similarity_function=tc.attribute.configuration.SimilarityFunction.ABSOLUTE_DIFF,
+        numeric_field_resolution=[10],
+    )
+
+    assert isinstance(updated_attr_conf, tc.AttributeConfiguration)
+    assert updated_attr_conf.attribute_role == AttributeRole.SUM_ATTRIBUTE
+    assert updated_attr_conf.similarity_function == SimilarityFunction.ABSOLUTE_DIFF
+    assert updated_attr_conf.enabled_for_ml
+    assert updated_attr_conf.tokenizer == Tokenizer.NONE
+    assert updated_attr_conf.numeric_field_resolution == [10]
+    assert isinstance(updated_attr_conf.attribute, tc.Attribute)
+    assert updated_attr_conf.attribute.name == "StreetAddress"
+
+
+@fake.json
+def test_delete():
+    s = fake.session()
+    attribute_conf = fake.attribute_configuration()
+    tc.attribute.configuration.delete(s, attribute_conf)
+
+
+@fake.json
+def test_by_resource_id_attribute_configuration_not_found():
+    s = fake.session()
+    project = fake.mastering_project()
+
+    with pytest.raises(tc.attribute.configuration.NotFound):
+        tc.attribute.configuration.by_resource_id(s, project, "1600")
+
+
+@fake.json
+def test_create_attribute_configuration_exists():
+    s = fake.session()
+    project = fake.mastering_project()
+    attribute = fake.project_attribute()
+
+    with pytest.raises(tc.attribute.configuration.AlreadyExists):
+        tc.attribute.configuration.create(s, project, unified_attribute=attribute)
+
+
+@fake.json
+def test_update_attribute_configuration_not_found():
+    s = fake.session()
+    attribute_conf = fake.attribute_configuration()
+
+    with pytest.raises(tc.attribute.configuration.NotFound):
+        tc.attribute.configuration.update(
+            s, attribute_conf,
+        )

--- a/tests/tamr_client/fake.py
+++ b/tests/tamr_client/fake.py
@@ -224,3 +224,25 @@ def attribute_mapping() -> tc.AttributeMapping:
             is_nullable=False,
         ),
     )
+
+
+def project_attribute() -> tc.Attribute:
+    return tc.Attribute(
+        url=tc.URL(path="projects/1/attributes/StreetAddress"),
+        name="StreetAddress",
+        type=tc.attribute.type.DEFAULT,
+        description="A Mastering Project attribute",
+        is_nullable=False,
+    )
+
+
+def attribute_configuration() -> tc.AttributeConfiguration:
+    return tc.AttributeConfiguration(
+        url=tc.URL(path="projects/1/attributeConfigurations/1600"),
+        attribute=project_attribute(),
+        attribute_role=tc.attribute.configuration.AttributeRole.NONE,
+        similarity_function=tc.attribute.configuration.SimilarityFunction.COSINE,
+        enabled_for_ml=True,
+        tokenizer=tc.attribute.configuration.Tokenizer.DEFAULT,
+        numeric_field_resolution=[],
+    )

--- a/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_by_resource_id.json
+++ b/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_by_resource_id.json
@@ -1,0 +1,44 @@
+[
+    {
+        "request": {
+            "method": "GET",
+            "path": "projects/1/attributeConfigurations/1600"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/projects/1/attributeConfigurations/1600",
+                "relativeId": "projects/1/attributeConfigurations/1600",
+                "relativeAttributeId": "datasets/1/attributes/StreetAddress",
+                "attributeRole": "",
+                "similarityFunction": "COSINE",
+                "enabledForMl": true,
+                "tokenizer": "DEFAULT",
+                "numericFieldResolution": [],
+                "attributeName": "StreetAddress"
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "projects/1/attributes/StreetAddress"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "name": "StreetAddress",
+                "description": "A Mastering Project attribute",
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING",
+                        "attributes": []
+                    },
+                    "attributes": []
+                },
+                "isNullable": false
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_by_resource_id_attribute_configuration_not_found.json
+++ b/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_by_resource_id_attribute_configuration_not_found.json
@@ -1,0 +1,11 @@
+[
+    {
+        "request": {
+            "method": "GET",
+            "path": "projects/1/attributeConfigurations/1600"
+        },
+        "response": {
+            "status": 404
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_create.json
+++ b/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_create.json
@@ -1,0 +1,30 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects/1/attributeConfigurations",
+            "json": {
+                "attributeRole": "CLUSTER_NAME_ATTRIBUTE",
+                "similarityFunction": "COSINE",
+                "enabledForMl": true,
+                "tokenizer": "DEFAULT",
+                "numericFieldResolution": [],
+                "attributeName": "StreetAddress"
+            }
+        },
+        "response": {
+            "status": 201,
+            "json": {
+                "id": "unify://unified-data/v1/projects/1/attributeConfigurations/1600",
+                "relativeId": "projects/1/attributeConfigurations/1600",
+                "relativeAttributeId": "datasets/1/attributes/StreetAddress",
+                "attributeRole": "CLUSTER_NAME_ATTRIBUTE",
+                "similarityFunction": "COSINE",
+                "enabledForMl": true,
+                "tokenizer": "DEFAULT",
+                "numericFieldResolution": [],
+                "attributeName": "StreetAddress"
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_create_attribute_configuration_exists.json
+++ b/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_create_attribute_configuration_exists.json
@@ -1,0 +1,11 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects/1/attributeConfigurations"
+        },
+        "response": {
+            "status": 409
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_create_numeric.json
+++ b/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_create_numeric.json
@@ -1,0 +1,30 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects/1/attributeConfigurations",
+            "json": {
+                "attributeRole": "",
+                "similarityFunction": "ABSOLUTE_DIFF",
+                "enabledForMl": true,
+                "tokenizer": "",
+                "numericFieldResolution": [],
+                "attributeName": "StreetAddress"
+            }
+        },
+        "response": {
+            "status": 201,
+            "json": {
+                "id": "unify://unified-data/v1/projects/1/attributeConfigurations/1600",
+                "relativeId": "projects/1/attributeConfigurations/1600",
+                "relativeAttributeId": "datasets/1/attributes/StreetAddress",
+                "attributeRole": "",
+                "similarityFunction": "ABSOLUTE_DIFF",
+                "enabledForMl": true,
+                "tokenizer": "",
+                "numericFieldResolution": [],
+                "attributeName": "StreetAddress"
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_delete.json
+++ b/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_delete.json
@@ -1,0 +1,11 @@
+[
+    {
+        "request": {
+            "method": "DELETE",
+            "path": "projects/1/attributeConfigurations/1600"
+        },
+        "response": {
+            "status": 204
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_get_all.json
+++ b/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_get_all.json
@@ -1,0 +1,79 @@
+[
+    {
+        "request": {
+            "method": "GET",
+            "path": "projects/1/attributeConfigurations"
+        },
+        "response": {
+            "status": 200,
+            "json": [
+                {
+                    "id": "unify://unified-data/v1/projects/1/attributeConfigurations/1600",
+                    "relativeId": "projects/1/attributeConfigurations/1600",
+                    "relativeAttributeId": "datasets/1/attributes/StreetAddress",
+                    "attributeRole": "",
+                    "similarityFunction": "COSINE",
+                    "enabledForMl": true,
+                    "tokenizer": "DEFAULT",
+                    "numericFieldResolution": [],
+                    "attributeName": "StreetAddress"
+                },
+                {
+                    "id": "unify://unified-data/v1/projects/1/attributeConfigurations/1601",
+                    "relativeId": "projects/1/attributeConfigurations/1601",
+                    "relativeAttributeId": "datasets/1/attributes/StreetAddress2",
+                    "attributeRole": "",
+                    "similarityFunction": "JACCARD",
+                    "enabledForMl": true,
+                    "tokenizer": "BIWORD",
+                    "numericFieldResolution": [],
+                    "attributeName": "StreetAddress2"
+                }
+            ]
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "projects/1/attributes/StreetAddress"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "name": "StreetAddress",
+                "description": "A Mastering Project attribute",
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING",
+                        "attributes": []
+                    },
+                    "attributes": []
+                },
+                "isNullable": false
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "projects/1/attributes/StreetAddress2"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "name": "StreetAddress2",
+                "description": "A Mastering Project attribute",
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING",
+                        "attributes": []
+                    },
+                    "attributes": []
+                },
+                "isNullable": false
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_update.json
+++ b/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_update.json
@@ -1,0 +1,34 @@
+[
+    {
+        "request": {
+            "method": "PUT",
+            "path": "projects/1/attributeConfigurations/1600",
+            "json": {
+                "attributeRole": "SUM_ATTRIBUTE",
+                "similarityFunction": "ABSOLUTE_DIFF",
+                "enabledForMl": true,
+                "tokenizer": "",
+                "numericFieldResolution": [
+                    10
+                ],
+                "attributeName": "StreetAddress"
+            }
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/projects/1/attributeConfigurations/1600",
+                "relativeId": "projects/1/attributeConfigurations/1600",
+                "relativeAttributeId": "datasets/1/attributes/StreetAddress",
+                "attributeRole": "SUM_ATTRIBUTE",
+                "similarityFunction": "ABSOLUTE_DIFF",
+                "enabledForMl": true,
+                "tokenizer": "",
+                "numericFieldResolution": [
+                    10
+                ],
+                "attributeName": "StreetAddress"
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_update_attribute_configuration_not_found.json
+++ b/tests/tamr_client/fake_json/attribute/test_attribute_configuration/test_update_attribute_configuration_not_found.json
@@ -1,0 +1,11 @@
+[
+    {
+        "request": {
+            "method": "PUT",
+            "path": "projects/1/attributeConfigurations/1600"
+        },
+        "response": {
+            "status": 404
+        }
+    }
+]


### PR DESCRIPTION
# ↪️ Pull Request

This PR adds CRUD support for attribute configurations.

Open questions:
- Namespacing
- Enumeration for `SimilarityFunction`, `Tokenizer`, and `AttributeRole`
- Guard rails, e.g. prevent specifying non-null tokenizer if similarity function is not cosine or Jaccard

Possible breaking change: I noticed that `attribute_mapping.get_all(...)` returns a list instead of a tuple, like the other `get_all` functions.  This PR includes a commit to change this, but that may not be too important and could constitute a breaking change.

## 💻 Examples
```python
import tamr_client as tc
s = tc.Session(...)
instance = tc.Instance(...)
project = tc.Project(...)
ud = tc.dataset.unified.from_project(s, project)
attr = tc.attribute.by_resource_id(s, ud, "my_attr")

# Create
new_attr_config = tc.attribute.configuration.create(
    s,
    project,
    unified_attribute = attr,
    similarity_function=tc.attribute.configuration.SimilarityFunction.JACCARD,
    tokenizer=tc.attribute.configuration.Tokenizer.BIWORD,
    attribute_role=tc.attribute.configuration.AttributeRole.NONE,  # will be set to this by default but can be done explicitly
)

# Read
attr_configs = tc.attribute.configuration.get_all(s, project)
attr_config = tc.attribute.configuration.by_resource_id(s, project, "<config_id>")

# Update
updated_attr_config = tc.attribute.configuration.update(
    s,
    attr_config,
    similarity_function=tc.attribute.configuration.SimilarityFunction.ABSOLUTE_DIFF,
    attribute_role=tc.attribute.configuration.AttributeRole.SUM_ATTRIBUTE,
    numeric_field_resolution=[1],
)
    
# Delete
tc.attribute.configuration.delete(s, new_attr_config)
```

## ✔️ PR Todo

- [ ] Testing for this change
- [ ] Links to related issues/PRs
- [ ] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/main/docs) + docstrings
